### PR TITLE
Use nanmean and nanstd

### DIFF
--- a/upp/stages/normalisation.py
+++ b/upp/stages/normalisation.py
@@ -33,8 +33,8 @@ class Normalisation:
             for var in self.variables[name]["inputs"]:
                 if var in ["valid"]:
                     continue
-                mean = float(np.mean(array[var]))
-                std = float(np.std(array[var]))
+                mean = float(np.nanmean(array[var]))
+                std = float(np.nanstd(array[var]))
                 norm_dict[name][var] = {"mean": mean, "std": std}
         return norm_dict, len(batch[self.variables.jets_name])
 


### PR DESCRIPTION
For cases where valid objects (in this case flow objects) have NaNs for some inputs we should use `np.nanmean` instead of `np.mean` and similarly for the standard deviation calculation. 

Also added a check to see if the config file exists as good practice