### PR TITLE
Adding an option to get equal number of jets from each sample

### DIFF
--- a/upp/classes/components.py
+++ b/upp/classes/components.py
@@ -18,7 +18,7 @@ class Component:
     dirname: Path
     num_jets: int
     num_jets_estimate: int
-    equal_jets: bool
+    equal_jets: bool = True
 
     def __post_init__(self):
         self.hist = Hist(self.dirname.parent.parent / "hists" / f"hist_{self.name}.h5")
@@ -92,7 +92,7 @@ class Components:
             region_cuts = Cuts.empty() if pp_cfg.is_test else Cuts.from_list(c["region"]["cuts"])
             region = Region(c["region"]["name"], region_cuts + pp_cfg.global_cuts)
             pattern = c["sample"]["pattern"]
-            equal_jets = c["sample"]["equal_jets"]
+            equal_jets = c["sample"].get("equal_jets", True)
             if isinstance(pattern, list):
                 pattern = tuple(pattern)
             sample = Sample(pattern=pattern, ntuple_dir=pp_cfg.ntuple_dir, name=c["sample"]["name"])

--- a/upp/classes/components.py
+++ b/upp/classes/components.py
@@ -11,7 +11,6 @@ from upp.stages.hist import Hist
 
 @dataclass
 class Component:
-    # (DONE) probably need equal_jets here too
     region: Region
     sample: Sample
     flavour: Flavour
@@ -25,7 +24,6 @@ class Component:
         self.hist = Hist(self.dirname.parent.parent / "hists" / f"hist_{self.name}.h5")
 
     def setup_reader(self, batch_size, fname=None):
-        # (Done) equal_jets here?
         if fname is None:
             fname = self.sample.path
         self.reader = H5Reader(fname, batch_size, equal_jets=self.equal_jets)
@@ -58,7 +56,6 @@ class Component:
 
     def check_num_jets(self, num_jets, sampling_frac=None, cuts=None, silent=False):
         """Check if num_jets jets are aviailable after the cuts and sampling fraction."""
-        # (DONE) (NO NEED) THIS reader must get the equal_jets flag to know how many jets to estimate
         total = self.reader.estimate_available_jets(cuts, self.num_jets_estimate)
         available = total
         if sampling_frac:
@@ -90,7 +87,6 @@ class Components:
 
     @classmethod
     def from_config(cls, pp_cfg):
-        # (DONE) Here need to read from config file for equal_jets
         components = []
         for c in pp_cfg.config["components"]:
             region_cuts = Cuts.empty() if pp_cfg.is_test else Cuts.from_list(c["region"]["cuts"])

--- a/upp/classes/components.py
+++ b/upp/classes/components.py
@@ -28,7 +28,9 @@ class Component:
         # (Done) equal_jets_from_samples here?
         if fname is None:
             fname = self.sample.path
-        self.reader = H5Reader(fname, batch_size, equal_jets_from_samples=self.equal_jets_from_samples)
+        self.reader = H5Reader(
+            fname, batch_size, equal_jets_from_samples=self.equal_jets_from_samples
+        )
         log.debug(f"Setup component reader at: {fname}")
 
     def setup_writer(self, variables):
@@ -96,6 +98,7 @@ class Components:
             region_cuts = Cuts.empty() if pp_cfg.is_test else Cuts.from_list(c["region"]["cuts"])
             region = Region(c["region"]["name"], region_cuts + pp_cfg.global_cuts)
             pattern = c["sample"]["pattern"]
+            equal_jets_from_samples = c["sample"]["equal_jets_from_samples"]
             if isinstance(pattern, list):
                 pattern = tuple(pattern)
             sample = Sample(pattern=pattern, ntuple_dir=pp_cfg.ntuple_dir, name=c["sample"]["name"])
@@ -105,7 +108,6 @@ class Components:
                     num_jets = num_jets // 10
                 elif pp_cfg.split == "test":
                     num_jets = c.get("num_jets_test", num_jets // 10)
-                equal_jets_from_samples = pp_cfg[name].get("equal_jets_from_samples", True)
                 components.append(
                     Component(
                         region,

--- a/upp/classes/components.py
+++ b/upp/classes/components.py
@@ -28,9 +28,7 @@ class Component:
         # (Done) equal_jets here?
         if fname is None:
             fname = self.sample.path
-        self.reader = H5Reader(
-            fname, batch_size, equal_jets=self.equal_jets
-        )
+        self.reader = H5Reader(fname, batch_size, equal_jets=self.equal_jets)
         log.debug(f"Setup component reader at: {fname}")
 
     def setup_writer(self, variables):

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -141,21 +141,21 @@ class Resampling:
 
         # groupby samples
         for sample, cs in components.groupby_sample():
-            # make sure all tags equal_jets_from_samples are the same
-            equal_jets_flags = [c.equal_jets_from_samples for c in cs]
+            # make sure all tags equal_jets are the same
+            equal_jets_flags = [c.equal_jets for c in cs]
             if not all(flag == equal_jets_flags[0] for flag in equal_jets_flags):
                 raise ValueError(
-                    "equal_jets_from_samples must be the same for all components in a sample"
+                    "equal_jets must be the same for all components in a sample"
                 )
             equal_jets_flag = equal_jets_flags[0]
 
             # setup input stream
             variables = self.variables.add_jet_vars(cs.cuts.variables)
-            # (DONE) THIS reader must have the equal_jets_from_samples flag to know whether to stop when 1 stream is exhausted
+            # (DONE) THIS reader must have the equal_jets flag to know whether to stop when 1 stream is exhausted
             reader = H5Reader(
                 sample.path,
                 self.batch_size,
-                equal_jets_from_samples=equal_jets_flag,
+                equal_jets=equal_jets_flag,
             )
             stream = reader.stream(variables.combined(), reader.num_jets, region.cuts)
 

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -144,9 +144,7 @@ class Resampling:
             # make sure all tags equal_jets are the same
             equal_jets_flags = [c.equal_jets for c in cs]
             if not all(flag == equal_jets_flags[0] for flag in equal_jets_flags):
-                raise ValueError(
-                    "equal_jets must be the same for all components in a sample"
-                )
+                raise ValueError("equal_jets must be the same for all components in a sample")
             equal_jets_flag = equal_jets_flags[0]
 
             # setup input stream

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -149,12 +149,7 @@ class Resampling:
 
             # setup input stream
             variables = self.variables.add_jet_vars(cs.cuts.variables)
-            # (DONE) THIS reader must have the equal_jets flag to know whether to stop when 1 stream is exhausted
-            reader = H5Reader(
-                sample.path,
-                self.batch_size,
-                equal_jets=equal_jets_flag,
-            )
+            reader = H5Reader(sample.path, self.batch_size, equal_jets=equal_jets_flag)
             stream = reader.stream(variables.combined(), reader.num_jets, region.cuts)
 
             # run with progress

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -141,10 +141,22 @@ class Resampling:
 
         # groupby samples
         for sample, cs in components.groupby_sample():
+            # make sure all tags equal_jets_from_samples are the same
+            equal_jets_flags = [c.equal_jets_from_samples for c in cs]
+            if not all(flag == equal_jets_flags[0] for flag in equal_jets_flags):
+                raise ValueError(
+                    "equal_jets_from_samples must be the same for all components in a sample"
+                )
+            equal_jets_flag = equal_jets_flags[0]
+
             # setup input stream
             variables = self.variables.add_jet_vars(cs.cuts.variables)
             # (DONE) THIS reader must have the equal_jets_from_samples flag to know whether to stop when 1 stream is exhausted
-            reader = H5Reader(sample.path, self.batch_size, equal_jets_from_samples=self.config[sample]["equal_jets_from_samples"])
+            reader = H5Reader(
+                sample.path,
+                self.batch_size,
+                equal_jets_from_samples=equal_jets_flag,
+            )
             stream = reader.stream(variables.combined(), reader.num_jets, region.cuts)
 
             # run with progress

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -143,7 +143,7 @@ class Resampling:
         for sample, cs in components.groupby_sample():
             # make sure all tags equal_jets are the same
             equal_jets_flags = [c.equal_jets for c in cs]
-            if not all(flag == equal_jets_flags[0] for flag in equal_jets_flags):
+            if len(set(equal_jets_flags)) != 1:
                 raise ValueError("equal_jets must be the same for all components in a sample")
             equal_jets_flag = equal_jets_flags[0]
 

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -143,7 +143,8 @@ class Resampling:
         for sample, cs in components.groupby_sample():
             # setup input stream
             variables = self.variables.add_jet_vars(cs.cuts.variables)
-            reader = H5Reader(sample.path, self.batch_size)
+            # (DONE) THIS reader must have the equal_jets_from_samples flag to know whether to stop when 1 stream is exhausted
+            reader = H5Reader(sample.path, self.batch_size, equal_jets_from_samples=self.config[sample]["equal_jets_from_samples"])
             stream = reader.stream(variables.combined(), reader.num_jets, region.cuts)
 
             # run with progress


### PR DESCRIPTION
The previous fix [atlas-ftag-tools](https://github.com/umami-hep/atlas-ftag-tools/) (PR [28](https://github.com/umami-hep/atlas-ftag-tools/pull/28)) introduced a problem (or rather highlighted an existing one) where when reading multiple samples in different streams, when one runs out it stops. While is is the intended behaviour in some cases, there are two problems:

1. Sometimes we want as many stats as possbile, rather than drawing equally from each sample.
2. Number of jets estimation takes an average of all samples, meaning if their number is unbalanced, it overestimates the number of available jets.

In this PR I've added a flag `equal_jets_from_samples` to be read from the config file to determine which behaviour we want, separate for each jet flavour.

This PR is related to [the other one](https://github.com/umami-hep/atlas-ftag-tools/pull/33) in atlas-ftag-tools