### PR TITLE
Transform pipeline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.254"
+    rev: "v0.0.275"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/upp/classes/components.py
+++ b/upp/classes/components.py
@@ -23,16 +23,14 @@ class Component:
     def __post_init__(self):
         self.hist = Hist(self.dirname.parent.parent / "hists" / f"hist_{self.name}.h5")
 
-    def setup_reader(self, batch_size, fname=None):
+    def setup_reader(self, batch_size, fname=None, **kwargs):
         if fname is None:
             fname = self.sample.path
-        self.reader = H5Reader(fname, batch_size, equal_jets=self.equal_jets)
+        self.reader = H5Reader(fname, batch_size, equal_jets=self.equal_jets, **kwargs)
         log.debug(f"Setup component reader at: {fname}")
 
     def setup_writer(self, variables):
-        self.writer = H5Writer(
-            self.reader.files[0], self.out_path, variables.combined(), self.num_jets
-        )
+        self.writer = H5Writer(self.reader, self.out_path, variables.keys(), self.num_jets)
         log.debug(f"Setup component writer at: {self.out_path}")
 
     @property

--- a/upp/classes/preprocessing_config.py
+++ b/upp/classes/preprocessing_config.py
@@ -58,7 +58,9 @@ class PreprocessingConfig:
         self.sampl_cfg = ResamplingConfig(sampl_cfg.pop("variables"), **sampl_cfg)
         self.components = Components.from_config(self)
         self.variables = VariableConfig(self.config["variables"], self.jets_name, self.is_test)
-        self.transform = Transform(**self.config["transform"]) if "transform" in self.config else None
+        self.transform = (
+            Transform(**self.config["transform"]) if "transform" in self.config else None
+        )
 
         # copy config
         git_hash = check_output(["git", "rev-parse", "--short", "HEAD"], cwd=Path(__file__).parent)

--- a/upp/classes/preprocessing_config.py
+++ b/upp/classes/preprocessing_config.py
@@ -12,6 +12,7 @@ from typing import Literal
 import yaml
 from ftag import Cuts
 from yamlinclude import YamlIncludeConstructor
+from ftag.transform import Transform
 
 from upp.classes.components import Components
 from upp.classes.resampling_config import ResamplingConfig
@@ -57,6 +58,7 @@ class PreprocessingConfig:
         self.sampl_cfg = ResamplingConfig(sampl_cfg.pop("variables"), **sampl_cfg)
         self.components = Components.from_config(self)
         self.variables = VariableConfig(self.config["variables"], self.jets_name, self.is_test)
+        self.transform = Transform(**self.config["transform"])
 
         # copy config
         git_hash = check_output(["git", "rev-parse", "--short", "HEAD"], cwd=Path(__file__).parent)

--- a/upp/classes/preprocessing_config.py
+++ b/upp/classes/preprocessing_config.py
@@ -11,8 +11,8 @@ from typing import Literal
 
 import yaml
 from ftag import Cuts
-from yamlinclude import YamlIncludeConstructor
 from ftag.transform import Transform
+from yamlinclude import YamlIncludeConstructor
 
 from upp.classes.components import Components
 from upp.classes.resampling_config import ResamplingConfig

--- a/upp/classes/preprocessing_config.py
+++ b/upp/classes/preprocessing_config.py
@@ -58,7 +58,7 @@ class PreprocessingConfig:
         self.sampl_cfg = ResamplingConfig(sampl_cfg.pop("variables"), **sampl_cfg)
         self.components = Components.from_config(self)
         self.variables = VariableConfig(self.config["variables"], self.jets_name, self.is_test)
-        self.transform = Transform(**self.config["transform"])
+        self.transform = Transform(**self.config["transform"]) if "transform" in self.config else None
 
         # copy config
         git_hash = check_output(["git", "rev-parse", "--short", "HEAD"], cwd=Path(__file__).parent)

--- a/upp/classes/variable_config.py
+++ b/upp/classes/variable_config.py
@@ -39,7 +39,7 @@ class VariableConfig:
 
     def items(self):
         return self.variables.items()
-    
+
     def keys(self):
         return self.variables.keys()
 

--- a/upp/classes/variable_config.py
+++ b/upp/classes/variable_config.py
@@ -39,6 +39,9 @@ class VariableConfig:
 
     def items(self):
         return self.variables.items()
+    
+    def keys(self):
+        return self.variables.keys()
 
     def __iter__(self):
         yield from self.variables.keys()

--- a/upp/configs/single-b.yaml
+++ b/upp/configs/single-b.yaml
@@ -1,4 +1,5 @@
 variables: !include variables.yaml
+#transform: !include transform.yaml
 
 ttbar: &ttbar
   name: ttbar

--- a/upp/configs/transform.yaml
+++ b/upp/configs/transform.yaml
@@ -1,4 +1,13 @@
+# label renaming from https://gitlab.cern.ch/atlas/athena/-/merge_requests/62544
 variable_map:
   tracks:
     truthOriginLabel: ftagTruthOriginLabel
     truthVertexIndex: ftagTruthVertexIndex
+
+# accounting for a bug introduced in https://gitlab.cern.ch/atlas/athena/-/merge_requests/62544
+# fixed in https://gitlab.cern.ch/atlas/athena/-/merge_requests/64151
+# you shouldn't use this unless you know you need to, otherwise you will mess up the labels
+ints_map:
+  ftagTruthOriginLabel:
+    0: 1
+    -2: 0

--- a/upp/configs/transform.yaml
+++ b/upp/configs/transform.yaml
@@ -1,0 +1,4 @@
+variable_map:
+  tracks:
+    truthOriginLabel: ftagTruthOriginLabel
+    truthVertexIndex: ftagTruthVertexIndex

--- a/upp/configs/variables.yaml
+++ b/upp/configs/variables.yaml
@@ -37,6 +37,7 @@ tracks:
   labels:
     - truthOriginLabel
     - truthVertexIndex
+
 #flow:
 #  inputs:
 #    - pt

--- a/upp/stages/merging.py
+++ b/upp/stages/merging.py
@@ -64,9 +64,9 @@ class Merging:
         if sample:
             fname = path_append(fname, sample)
         self.writer = H5Writer(
-            components[0].reader.files[0],
+            components[0].reader,
             fname,
-            self.variables.combined(),
+            self.variables.keys(),
             components.num_jets,
             add_flavour_label=self.jets_name,
         )

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -37,14 +37,14 @@ class Resampling:
         self.batch_size = config.batch_size
         self.is_test = config.is_test
         self.num_jets_estimate = config.num_jets_estimate
-        if self.config.method == "pdf":
-            self.select_func = self.pdf_select_func
-        elif self.config.method == "countup":
-            self.select_func = self.countup_select_func
-        elif not self.config.method or self.config.method == "none":
-            self.select_func = None
-        else:
-            raise ValueError(f"Unsupported resampling method {self.config.method}")
+        self.methods_map = {
+            "pdf": self.pdf_select_func,
+            "countup": self.countup_select_func,
+            "none": None,
+        }
+        if self.config.method not in self.methods_map:
+            raise ValueError(f"Unsupported resampling method {self.config.method}, choose from {self.methods_map.keys()}")
+        self.select_func = self.methods_map[self.config.method]
         self.rng = np.random.default_rng(42)
 
     def countup_select_func(self, jets, component):  # noqa: ARG002

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -45,6 +45,8 @@ class Resampling:
         if self.config.method not in self.methods_map:
             raise ValueError(f"Unsupported resampling method {self.config.method}, choose from {self.methods_map.keys()}")
         self.select_func = self.methods_map[self.config.method]
+        self.transform = config.transform
+            
         self.rng = np.random.default_rng(42)
 
     def countup_select_func(self, jets, component):  # noqa: ARG002
@@ -149,7 +151,7 @@ class Resampling:
 
             # setup input stream
             variables = self.variables.add_jet_vars(cs.cuts.variables)
-            reader = H5Reader(sample.path, self.batch_size, equal_jets=equal_jets_flag)
+            reader = H5Reader(sample.path, self.batch_size, equal_jets=equal_jets_flag, transform=self.transform)
             stream = reader.stream(variables.combined(), reader.num_jets, region.cuts)
 
             # run with progress

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -43,10 +43,13 @@ class Resampling:
             "none": None,
         }
         if self.config.method not in self.methods_map:
-            raise ValueError(f"Unsupported resampling method {self.config.method}, choose from {self.methods_map.keys()}")
+            raise ValueError(
+                f"Unsupported resampling method {self.config.method}, choose from"
+                f" {self.methods_map.keys()}"
+            )
         self.select_func = self.methods_map[self.config.method]
         self.transform = config.transform
-            
+
         self.rng = np.random.default_rng(42)
 
     def countup_select_func(self, jets, component):  # noqa: ARG002
@@ -151,7 +154,9 @@ class Resampling:
 
             # setup input stream
             variables = self.variables.add_jet_vars(cs.cuts.variables)
-            reader = H5Reader(sample.path, self.batch_size, equal_jets=equal_jets_flag, transform=self.transform)
+            reader = H5Reader(
+                sample.path, self.batch_size, equal_jets=equal_jets_flag, transform=self.transform
+            )
             stream = reader.stream(variables.combined(), reader.num_jets, region.cuts)
 
             # run with progress
@@ -184,7 +189,10 @@ class Resampling:
 
         # setup i/o
         for c in self.components:
-            c.setup_reader(self.batch_size)
+            # just used for the writer configuration
+            c.setup_reader(
+                self.batch_size, transform=self.transform
+            )
             c.setup_writer(self.variables)
 
         # check samples

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -190,9 +190,7 @@ class Resampling:
         # setup i/o
         for c in self.components:
             # just used for the writer configuration
-            c.setup_reader(
-                self.batch_size, transform=self.transform
-            )
+            c.setup_reader(self.batch_size, transform=self.transform)
             c.setup_writer(self.variables)
 
         # check samples


### PR DESCRIPTION
closes #3 | requires https://github.com/umami-hep/atlas-ftag-tools/pull/44

Summary of changes: 

* improve resampling select func logic
* add transform pipeline at the resampling stage to rename ftag labels and map buggy values
* map buggy origin label
* bump ruff version