### PR TITLE
Continue if not enough jets for estimate

### DIFF
--- a/upp/classes/components.py
+++ b/upp/classes/components.py
@@ -53,8 +53,9 @@ class Component:
         jn = self.reader.jets_name
         return self.reader.load({jn: variables}, num_jets, cuts)[jn]
 
-    def check_num_jets(self, num_jets, sampling_frac=None, cuts=None, silent=False,
-                       raise_error=True):
+    def check_num_jets(
+        self, num_jets, sampling_frac=None, cuts=None, silent=False, raise_error=True
+    ):
         """Check if num_jets jets are aviailable after the cuts and sampling fraction."""
         total = self.reader.estimate_available_jets(cuts, self.num_jets_estimate)
         available = total
@@ -63,7 +64,6 @@ class Component:
 
         # check with tolerance to avoid failure midway through preprocessing
         if available < num_jets * 1.01 and raise_error:
-
             raise ValueError(
                 f"{num_jets:,} jets requested, but only {total:,} are estimated to be"
                 f" in {self}. With a sampling fraction of {sampling_frac}, at most"

--- a/upp/classes/components.py
+++ b/upp/classes/components.py
@@ -53,7 +53,8 @@ class Component:
         jn = self.reader.jets_name
         return self.reader.load({jn: variables}, num_jets, cuts)[jn]
 
-    def check_num_jets(self, num_jets, sampling_frac=None, cuts=None, silent=False):
+    def check_num_jets(self, num_jets, sampling_frac=None, cuts=None, silent=False,
+                       raise_error=True):
         """Check if num_jets jets are aviailable after the cuts and sampling fraction."""
         total = self.reader.estimate_available_jets(cuts, self.num_jets_estimate)
         available = total
@@ -61,7 +62,8 @@ class Component:
             available = int(total * sampling_frac)
 
         # check with tolerance to avoid failure midway through preprocessing
-        if available < num_jets * 1.01:
+        if available < num_jets * 1.01 and raise_error:
+
             raise ValueError(
                 f"{num_jets:,} jets requested, but only {total:,} are estimated to be"
                 f" in {self}. With a sampling fraction of {sampling_frac}, at most"

--- a/upp/stages/hist.py
+++ b/upp/stages/hist.py
@@ -104,8 +104,9 @@ def main(config=None):
         log.info(f"Estimating PDF for {c}")
         c.setup_reader(config.batch_size)
         cuts_no_split = c.cuts.ignore(["eventNumber"])
-        c.check_num_jets(config.num_jets_estimate, cuts=cuts_no_split, silent=False, 
-                         raise_error=False)
+        c.check_num_jets(
+            config.num_jets_estimate, cuts=cuts_no_split, silent=False, raise_error=False
+        )
         jets = c.get_jets(sampl_vars, config.num_jets_estimate, cuts_no_split)
         c.hist.write_hist(jets, sampl_vars, config.sampl_cfg.flat_bins)
 

--- a/upp/stages/hist.py
+++ b/upp/stages/hist.py
@@ -104,7 +104,11 @@ def main(config=None):
         log.info(f"Estimating PDF for {c}")
         c.setup_reader(config.batch_size)
         cuts_no_split = c.cuts.ignore(["eventNumber"])
-        c.check_num_jets(config.num_jets_estimate, cuts=cuts_no_split, silent=True)
+        try:
+            c.check_num_jets(config.num_jets_estimate, cuts=cuts_no_split, silent=True)
+        except ValueError as e:
+            log.warning(e)
+            log.warning("Ran out of jets when estimating PDFs, listed amount is total available jets")
         jets = c.get_jets(sampl_vars, config.num_jets_estimate, cuts_no_split)
         c.hist.write_hist(jets, sampl_vars, config.sampl_cfg.flat_bins)
 

--- a/upp/stages/hist.py
+++ b/upp/stages/hist.py
@@ -104,13 +104,8 @@ def main(config=None):
         log.info(f"Estimating PDF for {c}")
         c.setup_reader(config.batch_size)
         cuts_no_split = c.cuts.ignore(["eventNumber"])
-        try:
-            c.check_num_jets(config.num_jets_estimate, cuts=cuts_no_split, silent=True)
-        except ValueError as e:
-            log.warning(e)
-            log.warning(
-                "Ran out of jets when estimating PDFs, listed amount is total available jets"
-            )
+        c.check_num_jets(config.num_jets_estimate, cuts=cuts_no_split, silent=False, 
+                         raise_error=False)
         jets = c.get_jets(sampl_vars, config.num_jets_estimate, cuts_no_split)
         c.hist.write_hist(jets, sampl_vars, config.sampl_cfg.flat_bins)
 

--- a/upp/stages/hist.py
+++ b/upp/stages/hist.py
@@ -108,7 +108,9 @@ def main(config=None):
             c.check_num_jets(config.num_jets_estimate, cuts=cuts_no_split, silent=True)
         except ValueError as e:
             log.warning(e)
-            log.warning("Ran out of jets when estimating PDFs, listed amount is total available jets")
+            log.warning(
+                "Ran out of jets when estimating PDFs, listed amount is total available jets"
+            )
         jets = c.get_jets(sampl_vars, config.num_jets_estimate, cuts_no_split)
         c.hist.write_hist(jets, sampl_vars, config.sampl_cfg.flat_bins)
 


### PR DESCRIPTION
Closes #12, simply wraps a try/catch around the call for calculating estimate jets, allowing the script to continue. A warning is presented to the user.
This means when running upp over samples with large jet number differences, we don't have use an artificially small num_jets_estimate. Similarly, this now means an artificially large number of jets can be used in an estimate, reducing the change of incorrectly estimating total number of jets when running large samples.