### PR TITLE
Update single b-tag for mc20+mc23

### DIFF
--- a/upp/configs/single-b.yaml
+++ b/upp/configs/single-b.yaml
@@ -5,7 +5,7 @@ variables: !include variables.yaml
 ttbar: &ttbar
   name: ttbar
   equal_jets: False
-  pattern: 
+  pattern:
     - "mc20/user.nekumari.410470.e6337_s3681_r13144_p5770.tdd.EMPFlow.24_2_14.23-08-14_PFlow_Aug_23_output.h5/*.h5"
     - "mc23/user.nekumari.601229.e8514_s4162_r14622_p5770.tdd.EMPFlow.24_2_14.23-08-14_PFlow_Aug_23_output.h5/*.h5"
     - "mc23/user.nekumari.601230.e8514_s4162_r14622_p5770.tdd.EMPFlow.24_2_14.23-08-14_PFlow_Aug_23_output.h5/*.h5"
@@ -13,7 +13,7 @@ ttbar: &ttbar
 zprime: &zprime
   name: zprime
   equal_jets: False
-  pattern: 
+  pattern:
     - "mc20/user.nekumari.800030.e7954_s3681_r13144_p5770.tdd.EMPFlow.24_2_14.23-08-14_PFlow_Aug_23_output.h5/*.h5"
     - "mc20/user.nekumari.800030.e7954_s3797_r13144_p5770.tdd.EMPFlow.24_2_14.23-08-14_PFlow_Aug_23_output.h5/*.h5"
     - "mc23/user.nekumari.800030.e8514_s4162_r14622_p5770.tdd.EMPFlow.24_2_14.23-08-21_PFlow_Aug_23_fix_output.h5/*.h5"
@@ -97,4 +97,3 @@ global:
   num_jets_estimate: 5_000_000
   base_dir: /home/xzcappon/phd/datasets/combined_run2_run3/p5770/high_stats_320m
   ntuple_dir: /home/xzcappon/central_dumps/p5770
-

--- a/upp/configs/single-b.yaml
+++ b/upp/configs/single-b.yaml
@@ -1,12 +1,22 @@
-variables: !include variables.yaml
+# In this config, we don't have seperate samples for r2 or r3, we just combine them
+variables: !include /home/xzcappon/phd/tools/umami-preprocessing/upp/configs/variables.yaml
 #transform: !include transform.yaml
 
 ttbar: &ttbar
   name: ttbar
-  pattern: "*.410470.e6337_s3681_r13144_p5169.tdd.*.h5/*.h5"
+  equal_jets: False
+  pattern: 
+    - "mc20/user.nekumari.410470.e6337_s3681_r13144_p5770.tdd.EMPFlow.24_2_14.23-08-14_PFlow_Aug_23_output.h5/*.h5"
+    - "mc23/user.nekumari.601229.e8514_s4162_r14622_p5770.tdd.EMPFlow.24_2_14.23-08-14_PFlow_Aug_23_output.h5/*.h5"
+    - "mc23/user.nekumari.601230.e8514_s4162_r14622_p5770.tdd.EMPFlow.24_2_14.23-08-14_PFlow_Aug_23_output.h5/*.h5"
+
 zprime: &zprime
   name: zprime
-  pattern: "*.800030.e7954_s3681_r13144_p5169.tdd.*.h5/*.h5"
+  equal_jets: False
+  pattern: 
+    - "mc20/user.nekumari.800030.e7954_s3681_r13144_p5770.tdd.EMPFlow.24_2_14.23-08-14_PFlow_Aug_23_output.h5/*.h5"
+    - "mc20/user.nekumari.800030.e7954_s3797_r13144_p5770.tdd.EMPFlow.24_2_14.23-08-14_PFlow_Aug_23_output.h5/*.h5"
+    - "mc23/user.nekumari.800030.e8514_s4162_r14622_p5770.tdd.EMPFlow.24_2_14.23-08-21_PFlow_Aug_23_fix_output.h5/*.h5"
 
 global_cuts:
   train:
@@ -32,29 +42,49 @@ components:
       <<: *lowpt
     sample:
       <<: *ttbar
-    flavours: [cjets]
-    num_jets: 40_000_000
+    flavours: [bjets, cjets]
+    num_jets: 52_500_000
+    equal_jets: False
 
   - region:
       <<: *lowpt
     sample:
       <<: *ttbar
-    flavours: [bjets, ujets]
-    num_jets: 70_000_000
+    flavours: [ujets]
+    num_jets: 105_000_000
+    equal_jets: False
+
+  - region:
+      <<: *lowpt
+    sample:
+      <<: *ttbar
+    flavours: [taujets]
+    num_jets: 6_250_000
+    equal_jets: False
 
   - region:
       <<: *highpt
     sample:
       <<: *zprime
     flavours: [bjets, cjets]
-    num_jets: 9_000_000
+    num_jets: 21_000_000
+    equal_jets: False
 
   - region:
       <<: *highpt
     sample:
       <<: *zprime
     flavours: [ujets]
-    num_jets: 15_000_000
+    num_jets: 42_000_000
+    equal_jets: False
+
+  - region:
+      <<: *highpt
+    sample:
+      <<: *zprime
+    flavours: [taujets]
+    num_jets: 2_500_000
+    equal_jets: False
 
 resampling:
   target: cjets
@@ -71,5 +101,6 @@ global:
   jets_name: jets
   batch_size: 1_000_000
   num_jets_estimate: 5_000_000
-  base_dir: /unix/atlastracking/svanstroud/seminar/samples/
+  base_dir: /home/xzcappon/phd/datasets/combined_run2_run3/p5770/high_stats_320m
+  ntuple_dir: /home/xzcappon/central_dumps/p5770
 

--- a/upp/configs/single-b.yaml
+++ b/upp/configs/single-b.yaml
@@ -44,7 +44,6 @@ components:
       <<: *ttbar
     flavours: [bjets, cjets]
     num_jets: 52_500_000
-    equal_jets: False
 
   - region:
       <<: *lowpt
@@ -52,7 +51,6 @@ components:
       <<: *ttbar
     flavours: [ujets]
     num_jets: 105_000_000
-    equal_jets: False
 
   - region:
       <<: *lowpt
@@ -60,7 +58,6 @@ components:
       <<: *ttbar
     flavours: [taujets]
     num_jets: 6_250_000
-    equal_jets: False
 
   - region:
       <<: *highpt
@@ -68,7 +65,6 @@ components:
       <<: *zprime
     flavours: [bjets, cjets]
     num_jets: 21_000_000
-    equal_jets: False
 
   - region:
       <<: *highpt
@@ -76,7 +72,6 @@ components:
       <<: *zprime
     flavours: [ujets]
     num_jets: 42_000_000
-    equal_jets: False
 
   - region:
       <<: *highpt
@@ -84,7 +79,6 @@ components:
       <<: *zprime
     flavours: [taujets]
     num_jets: 2_500_000
-    equal_jets: False
 
 resampling:
   target: cjets

--- a/upp/configs/single-b.yaml
+++ b/upp/configs/single-b.yaml
@@ -1,5 +1,5 @@
 # In this config, we don't have seperate samples for r2 or r3, we just combine them
-variables: !include /home/xzcappon/phd/tools/umami-preprocessing/upp/configs/variables.yaml
+variables: !include variables.yaml
 #transform: !include transform.yaml
 
 ttbar: &ttbar


### PR DESCRIPTION
Updates to the single-btag configuration file, to include the full jet collection used in the final MC20+MC23 combined high-stats training. The total stats amounts to 302.75m jets
| Flavour | ttbar jets(m) | Z' jets (m) |
|----------|----------|----------|
| b-jets   | 52.5   | 21   |
| c-jets   | 52.5   | 21   |
| light-jets   | 105   | 42   |
| tau-jets   | 6.25   | 2.5   |
| Subtotal   | 216.25   | 86.5   |

Total: 302.75, 71.4% ttbar, 28.6% Z'

