### PR TITLE
save flavour_label to class_dict

### DIFF
--- a/upp/stages/normalisation.py
+++ b/upp/stages/normalisation.py
@@ -66,6 +66,9 @@ class Normalisation:
         for name, array in batch.items():
             if name != self.variables.jets_name:
                 array = array[array["valid"]]
+            if name == "jets":  # separate case for flavour_label
+                counts = np.unique(array["flavour_label"], return_counts=True)
+                class_dict[name]["flavour_label"] = counts
             for var in self.variables[name].get("labels", []):
                 if not np.issubdtype(array[var].dtype, np.integer) or any(s in var for s in ignore):
                     continue
@@ -119,7 +122,9 @@ class Normalisation:
         norm_dict = None
         class_dict = None
         total = None
-        stream = reader.stream(self.variables.combined(), self.num_jets)
+        vars = self.variables.combined()
+        vars["jets"].append("flavour_label")
+        stream = reader.stream(vars, self.num_jets)
 
         with ProgressBar() as progress:
             task = progress.add_task(

--- a/upp/stages/normalisation.py
+++ b/upp/stages/normalisation.py
@@ -67,7 +67,8 @@ class Normalisation:
         for name, array in batch.items():
             if name != self.variables.jets_name:
                 array = array[array["valid"]]
-            if name == self.variables.jets_name:  # separate case for flavour_label
+            # separate case for flavour_label
+            if name == self.variables.jets_name and "flavour_label" in array.dtype.names:
                 counts = np.unique(array["flavour_label"], return_counts=True)
                 class_dict[name]["flavour_label"] = counts
             for var in self.variables[name].get("labels", []):


### PR DESCRIPTION
Small (and a bit hacky) change to save `flavour_label` to `class_dict.yaml`, which would allow for reading class weights for the tasks in Salt automatically.

One potential issue is that the class weights are saved as lists, and are ordered differently between `flavour_label` and `R10TruthLabel_R22v1` (11, 12, 1, 10 vs 0, 1, 2, 3), so they are save in different order. Shouldn't break anything, but need to be careful about this later on in the Salt MR.