### PR TITLE
fixing issues with package installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dev = [
 preprocess = "upp.main:main"
 
 [tool.setuptools]
-packages = ["upp"]
+packages = ["upp", "upp.classes", "upp.stages"]
+include-package-data = true
 
 [tool.setuptools.dynamic]
 version = {attr = "upp.__version__"}

--- a/upp/__init__.py
+++ b/upp/__init__.py
@@ -1,4 +1,4 @@
 """UPP: Umami PreProcessing."""
 from __future__ import annotations
 
-__version__ = "v0.0.2"
+__version__ = "v0.0.3"


### PR DESCRIPTION
Whe installing package from PYPi ti does not work as modules `classes` and `steps` are not instaled. I add this to `projecttoml` and also make steps a module by adding `__init__.py` 