### PR TITLE
Updating Scipy version to match Umami

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "pyyaml-include==1.3",
     "PyYAML==6.0.1",
     "rich==12.6.0",
-    "scipy==1.9.3",
+    "scipy==1.10.1",
     "puma-hep==0.3.0",
     "atlas-ftag-tools==0.1.10",
     "dotmap==1.3.30"


### PR DESCRIPTION
Currently, Umami uses a different Scipy version (higher) which leads to an compatibility issue (see [here](https://gitlab.cern.ch/atlas-flavor-tagging-tools/algorithms/umami/-/jobs/33548657#L1264)).

The fix will be to fixate the scipy version in both repos. 