### PR TITLE
Update lxplus setup instructions

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -32,7 +32,7 @@ UPP requires Python 3.8 or later.
 
     ```bash
     setupATLAS
-    lsetup "python 3.9.11-x86_64-centos7"
+    lsetup "python 3.9.18-x86_64-centos7"
     ```
 
     !!!info "You can also [set up conda on lxplus](https://abpcomputing.web.cern.ch/guides/python_inst/)"
@@ -45,6 +45,8 @@ A simple installation can be done via `pip` from Python Packade Index:
 ```bash
 pip install umami-preprocessing
 ```
+
+!!!info "On lxplus you may have to use ```pip3 install umami-preprocessing``` due to pip otherwise defaulting to an older version of python"
 
 After this installation all the fuctionality for the user is available. The further steps are only useful for the development of the package.
 


### PR DESCRIPTION
### What
Updates the setup documentation to help people avoid issues arising from the use of an old python version on lxplus.
### How
Changes the setup instructions to use python 3.9.18 instead of 3.9.11. Also recommends using pip3 to avoid the defaulting to a very old version of pip.