### PR TITLE
fix configs for PLIT preprocessing

### DIFF
--- a/upp/configs/plit_electron_variables.yaml
+++ b/upp/configs/plit_electron_variables.yaml
@@ -15,13 +15,16 @@ electrons:
 
 electron_tracks:
   inputs:
+    - pt
+    - eta
+    - phi
     - ptfrac
     - dr_trackjet
     # - dr_lepton # not available right now due to happy little accident in creating the ntuples
     - btagIp_d0
     - btagIp_z0SinTheta
     - btagIp_d0Uncertainty
-    - btagIp_z0SinTheta
+    - btagIp_z0SinThetaUncertainty
     - btagIp_d0_significance
     - btagIp_z0SinTheta_significance
     - numberOfPixelHits
@@ -33,6 +36,7 @@ electron_tracks:
     - numberOfPixelSplitHits
     - numberOfSCTHits
     - numberOfSCTSharedHits
+    - numberOfTRTHits
   labels:
     - ftagTruthOriginLabel
     - ftagTruthTypeLabel

--- a/upp/configs/plit_muon_variables.yaml
+++ b/upp/configs/plit_muon_variables.yaml
@@ -16,13 +16,16 @@ muons:
 
 muon_tracks:
   inputs:
+    - pt
+    - eta
+    - phi
     - ptfrac
     - dr_trackjet
     # - dr_lepton # not available right now due to happy little accident in creating the ntuples
     - btagIp_d0
     - btagIp_z0SinTheta
     - btagIp_d0Uncertainty
-    - btagIp_z0SinTheta
+    - btagIp_z0SinThetaUncertainty
     - btagIp_d0_significance
     - btagIp_z0SinTheta_significance
     - numberOfPixelHits


### PR DESCRIPTION
This MR fixes the configs for the lepton isolation tagging preprocessing.
Due to an oversight, a variable was not added and another one twice.

This also adds the TRT hits for electron tracks. 
(Note: adding the TRT PID might help to discriminate against pions, check this out in subsequent MR)