### PR TITLE
Allow user to set custom flavour yaml path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "rich==12.6.0",
     "scipy==1.10.1",
     "puma-hep==0.3.0",
-    "atlas-ftag-tools==0.1.13",
+    "atlas-ftag-tools==0.1.14",
     "dotmap==1.3.30"
 ]
 

--- a/upp/classes/components.py
+++ b/upp/classes/components.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
-from ftag import Cuts, Flavour, Flavours, Sample
+from ftag import Cuts, Flavour, Sample
 from ftag.hdf5 import H5Reader, H5Writer
 
 from upp.classes.region import Region
@@ -121,7 +121,7 @@ class Components:
                     Component(
                         region,
                         sample,
-                        Flavours[name],
+                        pp_cfg.flavour_cont[name],
                         pp_cfg.global_cuts,
                         pp_cfg.components_dir,
                         num_jets,

--- a/upp/classes/preprocessing_config.py
+++ b/upp/classes/preprocessing_config.py
@@ -11,8 +11,8 @@ from typing import Literal
 import yaml
 from dotmap import DotMap
 from ftag import Cuts
-from ftag.git_check import get_git_hash
 from ftag.flavour import FlavourContainer
+from ftag.git_check import get_git_hash
 from ftag.transform import Transform
 from yamlinclude import YamlIncludeConstructor
 
@@ -89,7 +89,7 @@ class PreprocessingConfig:
     num_jets_estimate: int = 1_000_000
     merge_test_samples: bool = False
     jets_name: str = "jets"
-    flavour_config: Path = None
+    flavour_config: Path | None = None
 
     def __post_init__(self):
         # postprocess paths
@@ -100,7 +100,7 @@ class PreprocessingConfig:
             raise FileNotFoundError(f"Path {self.ntuple_dir} does not exist")
         self.components_dir = self.components_dir / self.split
         self.out_fname = self.out_dir / path_append(self.out_fname, self.split)
-        self.flavour_cont = FlavourContainer.from_yaml(flavour_config)
+        self.flavour_cont = FlavourContainer.from_yaml(self.flavour_config)
 
         # configure classes
         sampl_cfg = copy(self.config["resampling"])

--- a/upp/classes/preprocessing_config.py
+++ b/upp/classes/preprocessing_config.py
@@ -12,6 +12,7 @@ import yaml
 from dotmap import DotMap
 from ftag import Cuts
 from ftag.git_check import get_git_hash
+from ftag.flavour import FlavourContainer
 from ftag.transform import Transform
 from yamlinclude import YamlIncludeConstructor
 
@@ -88,6 +89,7 @@ class PreprocessingConfig:
     num_jets_estimate: int = 1_000_000
     merge_test_samples: bool = False
     jets_name: str = "jets"
+    flavour_config: Path = None
 
     def __post_init__(self):
         # postprocess paths
@@ -98,6 +100,7 @@ class PreprocessingConfig:
             raise FileNotFoundError(f"Path {self.ntuple_dir} does not exist")
         self.components_dir = self.components_dir / self.split
         self.out_fname = self.out_dir / path_append(self.out_fname, self.split)
+        self.flavour_cont = FlavourContainer.from_yaml(flavour_config)
 
         # configure classes
         sampl_cfg = copy(self.config["resampling"])

--- a/upp/stages/plot.py
+++ b/upp/stages/plot.py
@@ -4,6 +4,7 @@ import logging as log
 from pathlib import Path
 
 from ftag import Flavours
+from ftag.flavour import FlavourContainer
 from ftag.hdf5 import H5Reader
 from puma import Histogram, HistogramPlot
 
@@ -52,6 +53,7 @@ def make_hist(
     jets_name: str = "jets",
     bins_range: tuple | None = None,
     suffix: str = "",
+    flavour_cont: FlavourContainer = Flavours
 ) -> None:
     """
     Create and plot the histogram and save it to disk.
@@ -305,6 +307,7 @@ def plot_resampled_dists(config, stage: str) -> None:
         make_hist(
             stage=stage,
             flavours=config.components.flavours,
+            flavour_cont=config.flavour_cont,
             variable=var,
             in_paths=paths,
             jets_name=config.jets_name,
@@ -313,6 +316,7 @@ def plot_resampled_dists(config, stage: str) -> None:
             make_hist(
                 stage=stage,
                 flavours=config.components.flavours,
+                flavour_cont=config.flavour_cont,
                 variable=var,
                 in_paths=paths,
                 jets_name=config.jets_name,

--- a/upp/stages/plot.py
+++ b/upp/stages/plot.py
@@ -104,8 +104,8 @@ def make_hist(
         plot.add(
             Histogram(
                 df[df["flavour_label"] == label_value][variable],
-                label=Flavours[label_string].label,
-                colour=Flavours[label_string].colour,
+                label=flavour_cont[label_string].label,
+                colour=flavour_cont[label_string].colour,
             )
         )
 

--- a/upp/stages/plot.py
+++ b/upp/stages/plot.py
@@ -53,7 +53,7 @@ def make_hist(
     jets_name: str = "jets",
     bins_range: tuple | None = None,
     suffix: str = "",
-    flavour_cont: FlavourContainer = Flavours
+    flavour_cont: FlavourContainer = Flavours,
 ) -> None:
     """
     Create and plot the histogram and save it to disk.


### PR DESCRIPTION
Adds a new config option `flavour_config`, which allows the user to optionally specify the path to a custom yaml file in the style of https://github.com/umami-hep/atlas-ftag-tools/blob/main/ftag/flavours.yaml. This is useful in case you want to use `upp` to resample datasets which have non-standard labeling scheme.

Follow-up to https://github.com/umami-hep/atlas-ftag-tools/pull/65.

Addresses #51 