### PR TITLE
Updating with only c-jet classes split

### DIFF
--- a/upp/configs/extended_labels.yaml
+++ b/upp/configs/extended_labels.yaml
@@ -58,7 +58,7 @@ components:
     equal_jets: False
 
 resampling:
-  target: lepbjets
+  target: bjets
   method: pdf
   sampling_fraction: auto
   variables:

--- a/upp/configs/extended_labels.yaml
+++ b/upp/configs/extended_labels.yaml
@@ -49,7 +49,7 @@ components:
     num_jets: 50_000_000
     equal_jets: False
 
-- region:
+  - region:
       <<: *lowpt
     sample:
       <<: *ttbar

--- a/upp/configs/extended_labels.yaml
+++ b/upp/configs/extended_labels.yaml
@@ -21,16 +21,8 @@ components:
       <<: *lowpt
     sample:
       <<: *ttbar
-    flavours: [lepbjets]
-    num_jets: 12_500_000
-    equal_jets: False
-
-  - region:
-      <<: *lowpt
-    sample:
-      <<: *ttbar
-    flavours: [hadrbjets]
-    num_jets: 12_500_000
+    flavours: [bjets]
+    num_jets: 25_000_000
     equal_jets: False
 
   - region:
@@ -53,19 +45,11 @@ components:
       <<: *lowpt
     sample:
       <<: *ttbar
-    flavours: [lquarkjets]
-    num_jets: 25_000_000
+    flavours: [ujets]
+    num_jets: 50_000_000
     equal_jets: False
 
-  - region:
-      <<: *lowpt
-    sample:
-      <<: *ttbar
-    flavours: [gluonjets]
-    num_jets: 25_000_000
-    equal_jets: False
-
-  - region:
+- region:
       <<: *lowpt
     sample:
       <<: *ttbar


### PR DESCRIPTION
The default extended labelling config only has c-jets classes split to D0 meson and non D0meson.
FYI: @samvanstroud 