### PR TITLE
define python version for new install

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -12,7 +12,7 @@ UPP requires Python 3.8 or later.
     Set up a fresh [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/linux.html) or [mamba](https://github.com/conda-forge/miniforge#install) environment:
 
     ```bash
-    mamba create -n upp python
+    mamba create -n upp python=3.11
     mamba activate upp
     ```
 


### PR DESCRIPTION
When installing from fresh based on instructions in docs, I had errors (specifically, matching scipy version not found). By instead installing python 3.11 everything works (default seems to be 3.12)