### PR TITLE
Add d0,z0 electron variables

### DIFF
--- a/upp/configs/gn3/variables-ghost.yaml
+++ b/upp/configs/gn3/variables-ghost.yaml
@@ -74,6 +74,8 @@ electrons:
     - phi
     - ftag_et
     - qOverP
+    - ftag_z0AlongBeamspot
+    - d0RelativeToBeamspot
     - d0RelativeToBeamspotSignificance
     - ftag_z0AlongBeamspotSignificance
     - ftag_ptVarCone30OverPt


### PR DESCRIPTION
We missed these two variables in the preprocessing:
- `ftag_z0AlongBeamspot` 
- `d0RelativeToBeamspot`