### PR TITLE
Make resampling optional to allow for preprocessing of samples without flavour labels (data)

### DIFF
--- a/tests/unit/stages/test_plotting.py
+++ b/tests/unit/stages/test_plotting.py
@@ -32,6 +32,6 @@ class TestClass:
         make_hist_initial(
             "initial",
             config.components.flavours,
-            config.sampl_cfg.vars[0],
+            config.resampling_config.vars[0],
             ["tmp/upp-tests/integration/temp_workspace/ntuples/data1.h5"],
         )

--- a/upp/classes/variable_config.py
+++ b/upp/classes/variable_config.py
@@ -34,11 +34,17 @@ class VariableConfig:
     def tracks(self):
         return {name: var for name, var in self.variables.items() if name != self.jets_name}
 
-    def add_jet_vars(self, variables: list[str], kind: str = "inputs") -> VariableConfig:
+    def add_jet_vars(
+        self, variables: list[str], kind: str = "inputs"
+    ) -> VariableConfig:
         """Return a new VariableConfig instance."""
-        vc = VariableConfig(deepcopy(self.variables), self.jets_name, self.keep_all, self.selectors)
-        vc.jets[kind] = list(dict.fromkeys(vc.jets[kind] + variables))
-        return vc
+        variable_config = VariableConfig(
+            deepcopy(self.variables), self.jets_name, self.keep_all, self.selectors
+        )
+        variable_config.jets[kind] = list(
+            dict.fromkeys(variable_config.jets[kind] + variables)
+        )
+        return variable_config
 
     def items(self):
         return self.variables.items()

--- a/upp/stages/hist.py
+++ b/upp/stages/hist.py
@@ -132,21 +132,21 @@ def create_histograms(config) -> None:
 
     log.info(f"[bold green]Estimating PDFs using {config.num_jets_estimate_hist:,} jets...")
     sampl_vars = config.sampl_cfg.vars
-    for c in config.components:
-        log.info(f"Estimating {c} PDF using {config.num_jets_estimate_hist:,} samples...")
-        c.setup_reader(config.batch_size, config.jets_name)
-        cuts_no_split = c.cuts.ignore(["eventNumber"])
+    for component in config.components:
+        log.info(f"Estimating {component} PDF using {config.num_jets_estimate_hist:,} samples...")
+        component.setup_reader(config.batch_size, config.jets_name)
+        cuts_no_split = component.cuts.ignore(["eventNumber"])
 
         ###
         # TODO: return the number of jets here and pass to the next function to get started
         ###
-        c.check_num_jets(
+        component.check_num_jets(
             config.num_jets_estimate_hist,
             cuts=cuts_no_split,
             silent=False,
             raise_error=False,
         )
-        jets = c.get_jets(sampl_vars, config.num_jets_estimate_hist, cuts_no_split)
-        c.hist.write_hist(jets, sampl_vars, config.sampl_cfg.flat_bins)
+        jets = component.get_jets(sampl_vars, config.num_jets_estimate_hist, cuts_no_split)
+        component.hist.write_hist(jets, sampl_vars, config.sampl_cfg.flat_bins)
 
     log.info(f"[bold green]Saved to {config.components[0].hist.path.parent}/")

--- a/upp/stages/plot.py
+++ b/upp/stages/plot.py
@@ -53,7 +53,7 @@ def make_hist(
     jets_name: str = "jets",
     bins_range: tuple | None = None,
     suffix: str = "",
-    flavour_cont: LabelContainer = Flavours,
+    flavour_container: LabelContainer = Flavours,
 ) -> None:
     """
     Create and plot the histogram and save it to disk.
@@ -104,8 +104,8 @@ def make_hist(
         plot.add(
             Histogram(
                 df[df["flavour_label"] == label_value][variable],
-                label=flavour_cont[label_string].label,
-                colour=flavour_cont[label_string].colour,
+                label=flavour_container[label_string].label,
+                colour=flavour_container[label_string].colour,
             )
         )
 
@@ -307,7 +307,7 @@ def plot_resampled_dists(config, stage: str) -> None:
         make_hist(
             stage=stage,
             flavours=config.components.flavours,
-            flavour_cont=config.flavour_cont,
+            flavour_container=config.flavour_container,
             variable=var,
             in_paths=paths,
             jets_name=config.jets_name,
@@ -316,7 +316,7 @@ def plot_resampled_dists(config, stage: str) -> None:
             make_hist(
                 stage=stage,
                 flavours=config.components.flavours,
-                flavour_cont=config.flavour_cont,
+                flavour_container=config.flavour_container,
                 variable=var,
                 in_paths=paths,
                 jets_name=config.jets_name,

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -160,7 +160,7 @@ class Resampling:
 
     def run_on_region(self, components, region):
         # compute the target pdf
-        target = [c for c in components if c.is_target(self.config.target)]
+        target = [component for component in components if component.is_target(self.config.target)]
         assert len(target) == 1, "Should have 1 target component per region"
         self.target = target[0]
 
@@ -241,10 +241,12 @@ class Resampling:
         log.info(f"Resampling method: {self.config.method}")
 
         # setup i/o
-        for c in self.components:
+        for component in self.components:
             # just used for the writer configuration
-            c.setup_reader(self.batch_size, jets_name=self.jets_name, transform=self.transform)
-            c.setup_writer(self.variables, jets_name=self.jets_name)
+            component.setup_reader(
+                self.batch_size, jets_name=self.jets_name, transform=self.transform
+            )
+            component.setup_writer(self.variables, jets_name=self.jets_name)
 
         # set samplig fraction if needed
         self.set_component_sampling_fractions()
@@ -254,14 +256,14 @@ class Resampling:
             "[bold green]Checking requested num_jets based on a sampling fraction of"
             f" {self.config.sampling_fraction}..."
         )
-        for c in self.components:
-            frac = c.sampling_fraction if self.select_func else 1
-            c.check_num_jets(c.num_jets, sampling_frac=frac, cuts=c.cuts)
+        for component in self.components:
+            frac = component.sampling_fraction if self.select_func else 1
+            component.check_num_jets(component.num_jets, sampling_frac=frac, cuts=component.cuts)
 
         # run resampling
-        for region, components in self.components.groupby_region():
+        for region, component in self.components.groupby_region():
             log.info(f"[bold green]Running over region {region}...")
-            self.run_on_region(components, region)
+            self.run_on_region(component, region)
 
         # finalise
         unique = sum(c.writer.get_attr("unique_jets") for c in self.components)


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Makes the resampling and component flavour key optional

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
