### PR TITLE
Add config for the GN2XTau

### DIFF
--- a/upp/configs/xbb-variables.yaml
+++ b/upp/configs/xbb-variables.yaml
@@ -19,14 +19,14 @@ tracks:
     - pt
     - dr
     - d0
-    - IP3D_signed_d0
+    - lifetimeSignedD0
     - z0SinTheta
     - d0Uncertainty
     - dphi
     - deta
     - qOverP
-    - IP3D_signed_d0_significance
-    - IP3D_signed_z0_significance
+    - lifetimeSignedD0Significance
+    - lifetimeSignedZ0SinThetaSignificance
     - phiUncertainty
     - thetaUncertainty
     - qOverPUncertainty

--- a/upp/configs/xbb-variables.yaml
+++ b/upp/configs/xbb-variables.yaml
@@ -17,7 +17,6 @@ jets:
 tracks:
   inputs:
     - pt
-    - dr
     - d0
     - lifetimeSignedD0
     - z0SinTheta

--- a/upp/configs/xtautau.yaml
+++ b/upp/configs/xtautau.yaml
@@ -77,5 +77,5 @@ resampling:
 global:
   batch_size: 4_000_000
   num_jets_estimate: 5_000_000
-  base_dir: /atlas_cloud/fujimoto/samplesMC20d/
+  base_dir: /atlas_cloud/fujimoto/samplesMC23d/
   merge_test_samples: True

--- a/upp/configs/xtautau.yaml
+++ b/upp/configs/xtautau.yaml
@@ -1,0 +1,82 @@
+variables: !include xbb-variables.yaml
+global_cuts: !include splits/simple-split.yaml
+
+htautauhad: &htautauhad
+  name: htautauhad
+  pattern: /atlas_cloud/fujimoto/umamiMCd/user.mfujimot.802168.e8558_s4159_r15530_p6453.tdd.FatJets.25_2_34.prod_131224_output.h5/*.h5
+hbb: &hbb
+  name: hbb
+  pattern: /atlas_cloud/fujimoto/umamiMCd/user.mfujimot.801972.e8514_s4159_r15224_p6453.tdd.FatJets.25_2_34.prod_131224_output.h5/*.h5
+hcc: &hcc
+  name: hcc
+  pattern: /atlas_cloud/fujimoto/umamiMCd/user.mfujimot.801973.e8514_s4159_r15224_p6453.tdd.FatJets.25_2_34.prod_131224_output.h5/*.h5
+top: &top
+  name: top
+  #equal_jets: true
+  pattern: /atlas_cloud/fujimoto/umamiMCd/user.mfujimot.802423.e8514_s4159_r15530_p6453.tdd.FatJets.25_2_34.prod_131224_output.h5/*.h5
+qcd: &qcd
+  name: qcd
+  equal_jets: true
+  pattern:
+    - /atlas_cloud/fujimoto/umamiMCd/user.mfujimot.801168.e8514_s4159_r15224_p6453.tdd.FatJets.25_2_34.prod_131224_output.h5/*.h5
+    - /atlas_cloud/fujimoto/umamiMCd/user.mfujimot.801169.e8514_s4159_r15224_p6453.tdd.FatJets.25_2_34.prod_131224_output.h5/*.h5
+    - /atlas_cloud/fujimoto/umamiMCd/user.mfujimot.801170.e8514_s4159_r15224_p6453.tdd.FatJets.25_2_34.prod_131224_output.h5/*.h5
+
+inclusive: &inclusive
+  name: inclusive
+  cuts: []
+
+components:
+  - region:
+      <<: *inclusive
+    sample:
+      <<: *htautauhad
+    flavours: [htautauhad]
+    num_jets: 5_000_000
+
+  - region:
+      <<: *inclusive
+    sample:
+      <<: *hbb
+    flavours: [hbb]
+    num_jets: 14_500_000
+
+  - region:
+      <<: *inclusive
+    sample:
+      <<: *hcc
+    flavours: [hcc]
+    num_jets: 14_500_000
+
+  - region:
+      <<: *inclusive
+    sample:
+      <<: *top
+    flavours: [top]
+    num_jets: 8_000_000
+
+  - region:
+      <<: *inclusive
+    sample:
+      <<: *qcd
+    flavours: [qcd]
+    num_jets: 22_000_000
+
+resampling:
+  target: hbb
+  method: countup
+  sampling_fraction: 1
+  variables:
+    pt:
+      bins: [[250_000, 1_300_000, 50]]
+    abs_eta:
+      bins: [[0, 2, 20]]
+    mass:
+      bins: [[50_000, 300_000, 50]]
+
+# note: sensible defaults are defined in the PreprocessingConfig constructor
+global:
+  batch_size: 4_000_000
+  num_jets_estimate: 5_000_000
+  base_dir: /atlas_cloud/fujimoto/samplesMC20dMC23d/
+  merge_test_samples: True

--- a/upp/configs/xtautau.yaml
+++ b/upp/configs/xtautau.yaml
@@ -1,8 +1,8 @@
 variables: !include xbb-variables.yaml
 global_cuts: !include splits/simple-split.yaml
 
-htautauhad: &htautauhad
-  name: htautauhad
+htauhad: &htauhad
+  name: htauhad
   pattern: /atlas_cloud/fujimoto/umamiMCd/user.mfujimot.802168.e8558_s4159_r15530_p6453.tdd.FatJets.25_2_34.prod_131224_output.h5/*.h5
 hbb: &hbb
   name: hbb
@@ -30,8 +30,8 @@ components:
   - region:
       <<: *inclusive
     sample:
-      <<: *htautauhad
-    flavours: [htautauhad]
+      <<: *htauhad
+    flavours: [htauhad]
     num_jets: 5_000_000
 
   - region:

--- a/upp/configs/xtautau.yaml
+++ b/upp/configs/xtautau.yaml
@@ -77,5 +77,5 @@ resampling:
 global:
   batch_size: 4_000_000
   num_jets_estimate: 5_000_000
-  base_dir: /atlas_cloud/fujimoto/samplesMC20dMC23d/
+  base_dir: /atlas_cloud/fujimoto/samplesMC20d/
   merge_test_samples: True

--- a/upp/configs/xtautau.yaml
+++ b/upp/configs/xtautau.yaml
@@ -12,7 +12,6 @@ hcc: &hcc
   pattern: /atlas_cloud/fujimoto/umamiMCd/user.mfujimot.801973.e8514_s4159_r15224_p6453.tdd.FatJets.25_2_34.prod_131224_output.h5/*.h5
 top: &top
   name: top
-  #equal_jets: true
   pattern: /atlas_cloud/fujimoto/umamiMCd/user.mfujimot.802423.e8514_s4159_r15530_p6453.tdd.FatJets.25_2_34.prod_131224_output.h5/*.h5
 qcd: &qcd
   name: qcd


### PR DESCRIPTION
## Summary

This is the upp config file used for the GN2XTau [PubNote](https://cds.cern.ch/record/2925002) for the mc23d samples processed with [FatJets.json](https://gitlab.cern.ch/atlas-flavor-tagging-tools/training-dataset-dumper/-/blob/main/configs/FatJets.json?ref_type=heads) config.
This can be used after [this change](https://github.com/umami-hep/atlas-ftag-tools/pull/108) in atlas-ftag-tools.

This pull request introduces the following changes

* Added `upp/configs/xtautau.yaml` with own path for the samples. The statistics used here is consistent with the previous xbb config for the GN2X ( not the latest ).
* Needed some change in `upp/configs/xbb-variables.yaml` according to the [naming change](https://gitlab.cern.ch/atlas-flavor-tagging-tools/training-dataset-dumper/-/commit/2a390524c5dcf17ca4588536d1cac84a6aa670e7) in the TDD
* Also needed to remove `dr` from `upp/configs/xbb-variables.yaml` because this does not exist in the [pflow-track-variables.json](https://gitlab.cern.ch/atlas-flavor-tagging-tools/training-dataset-dumper/-/blob/main/configs/fragments/pflow-track-variables.json?ref_type=heads) in TDD for FatJets.json config 

Double-checked this config works with no problem with dedicated samples.