### PR TITLE
Fixing markdown autorefs version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Fixing markdown autorefs version [#88](https://github.com/umami-hep/umami-preprocessing/pull/88)
 - Adding parallel processing for prepare and resample steps [#84](https://github.com/umami-hep/umami-preprocessing/pull/84)
 
 ### [v0.2.2]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 mkdocs==1.4.2
 mkdocs-material==9.0.5
+mkdocs-autorefs==1.3.1
 mkdocstrings[python]
 mkdocs-markdownextradata-plugin>=0.2.5
 mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

*  Fixing docs publish by fixing the markdown autorefs version (1.4.0 is not working anymore)

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
