### PR TITLE
Removing redundent plotting code / Making labels nicer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Removing redundent plotting code / Making labels nicer [#89](https://github.com/umami-hep/umami-preprocessing/pull/89)
+
 ### [v0.2.3](https://github.com/umami-hep/umami-preprocessing/releases/tag/v0.2.3) (28.02.2025)
 
 - Fixing markdown autorefs version [#88](https://github.com/umami-hep/umami-preprocessing/pull/88)

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -100,7 +100,6 @@ class TestClass:
         args = [
             "--config",
             str(Path(this_dir / "fixtures/test_config_countup.yaml")),
-            "--no-plot",
             "--split",
             "train",
         ]

--- a/tests/unit/stages/test_plotting.py
+++ b/tests/unit/stages/test_plotting.py
@@ -35,3 +35,14 @@ class TestClass:
             variable=config.sampl_cfg.vars[0],
             in_paths_list=["tmp/upp-tests/integration/temp_workspace/ntuples/data1.h5"],
         )
+
+    def test_make_hist_initial_no_pt(self):
+        config = PreprocessingConfig.from_file(
+            Path("tests/integration/fixtures/test_config_pdf_auto.yaml"), "train"
+        )
+        make_hist(
+            stage="initial",
+            flavours=config.components.flavours,
+            variable="mass",
+            in_paths_list=["tmp/upp-tests/integration/temp_workspace/ntuples/data1.h5"],
+        )

--- a/tests/unit/stages/test_plotting.py
+++ b/tests/unit/stages/test_plotting.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from ftag import get_mock_file
 
 from upp.classes.preprocessing_config import PreprocessingConfig
-from upp.stages.plot import make_hist_initial
+from upp.stages.plot import make_hist
 
 
 class TestClass:
@@ -29,9 +29,9 @@ class TestClass:
         config = PreprocessingConfig.from_file(
             Path("tests/integration/fixtures/test_config_pdf_auto.yaml"), "train"
         )
-        make_hist_initial(
-            "initial",
-            config.components.flavours,
-            config.sampl_cfg.vars[0],
-            ["tmp/upp-tests/integration/temp_workspace/ntuples/data1.h5"],
+        make_hist(
+            stage="initial",
+            flavours=config.components.flavours,
+            variable=config.sampl_cfg.vars[0],
+            in_paths_list=["tmp/upp-tests/integration/temp_workspace/ntuples/data1.h5"],
         )

--- a/upp/classes/preprocessing_config.py
+++ b/upp/classes/preprocessing_config.py
@@ -87,6 +87,10 @@ class PreprocessingConfig:
         Number of jets of each flavour that are used to estimate shifting and scaling during
         normalisation step. Larger numbers give a better quality estmates.
         Is equal to num_jets_estimate by default.
+    num_jets_estimate_plotting : int
+        Number of jets of each flavour used for plotting the initial and the final resampling
+        variable distributions. Larger numbers give a better estimate of the full distributions.
+        Is equal to num_jets_estimate by default.
     jets_name : str
         Name of the jets dataset in the input file.
     """
@@ -104,6 +108,7 @@ class PreprocessingConfig:
     num_jets_estimate_available: int | None = None
     num_jets_estimate_hist: int | None = None
     num_jets_estimate_norm: int | None = None
+    num_jets_estimate_plotting: int | None = None
     merge_test_samples: bool = False
     jets_name: str = "jets"
     flavour_config: Path | None = None
@@ -117,6 +122,8 @@ class PreprocessingConfig:
                 self.num_jets_estimate_hist = self.num_jets_estimate
             if self.num_jets_estimate_norm is None:
                 self.num_jets_estimate_norm = self.num_jets_estimate
+            if self.num_jets_estimate_plotting is None:
+                self.num_jets_estimate_plotting = self.num_jets_estimate
 
         for field in dataclasses.fields(self):
             if field.type == "Path" and field.name != "out_fname" and field.name != "base_dir":

--- a/upp/main.py
+++ b/upp/main.py
@@ -21,7 +21,7 @@ from upp.logger import setup_logger
 from upp.stages.hist import create_histograms
 from upp.stages.merging import Merging
 from upp.stages.normalisation import Normalisation
-from upp.stages.plot import plot_initial_resampling_dists, plot_resampled_dists
+from upp.stages.plot import plot_resampling_dists
 from upp.stages.resampling import Resampling
 
 
@@ -95,8 +95,8 @@ def run_pp(args) -> None:
     if args.plot:
         title = " Plotting "
         log.info(f"[bold green]{title:-^100}")
-        plot_initial_resampling_dists(config=config)
-        plot_resampled_dists(config=config, stage=args.split)
+        plot_resampling_dists(config=config, stage="initial")
+        plot_resampling_dists(config=config, stage=args.split)
 
     # print end info
     end = datetime.now()

--- a/upp/stages/plot.py
+++ b/upp/stages/plot.py
@@ -2,128 +2,19 @@ from __future__ import annotations
 
 import logging as log
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from ftag import Flavours
+from ftag import Cuts
 from ftag.hdf5 import H5Reader
-from ftag.labels import LabelContainer
 from puma import Histogram, HistogramPlot
 
 from upp.utils import path_append
 
-
-def load_jets(
-    paths: str | list,
-    variable: str,
-    flavour_label="flavour_label",
-    jets_name="jets",
-) -> dict:
-    """
-    Load the variables and labels from the jets in a given file(s).
-
-    Parameters
-    ----------
-    paths : str | list
-        Path to the file which is to be loaded. Can be either a string
-        or a list. Wildcards are also supported.
-    variable : str
-        Variable which is to be loaded together with the labels.
-    flavour_label : str, optional
-        Name of the flavour label variable which is used for the labels,
-        by default "flavour_label"
-    jets_name: str, optional
-        Name of the jet dataset / the global objects
-        by default "jets"
-
-    Returns
-    -------
-    dict
-        Dict with the loaded variable and labels.
-    """
-    variables = {jets_name: [flavour_label, variable]}
-    reader = H5Reader(paths, batch_size=1000, jets_name=jets_name)
-    df = reader.load(variables, num_jets=10000)[jets_name]
-    return df
+if TYPE_CHECKING:  # pragma: no cover
+    from upp.classes.preprocessing_config import PreprocessingConfig
 
 
 def make_hist(
-    stage: str,
-    flavours: list,
-    variable: str,
-    in_paths: str | list,
-    jets_name: str = "jets",
-    bins_range: tuple | None = None,
-    suffix: str = "",
-    flavour_cont: LabelContainer = Flavours,
-) -> None:
-    """
-    Create and plot the histogram and save it to disk.
-
-    Parameters
-    ----------
-    stage : str
-        The stage in which the preprocessing is currently in.
-        Mainly used for the ouput name string.
-    flavours : list
-        List of the flavours that are to be plotted. The list
-        needs to contain the Flavour class instances from the
-        different flavours.
-    variable : str
-        Variable that is to be histogrammed and plotted.
-    in_paths : str
-        Path to the files from which the jets are loaded.
-    jets_name: str, optional
-        Name of the jet dataset / the global objects
-        by default "jets"
-    bins_range : tuple, optional
-        bins_range argument from from puma.HistogramPlot,
-        by default None
-    suffix : str, optional
-        A string suffix which is added to the plot
-        output name, by default "".
-    """
-    # Load the variable from the jets
-    df = load_jets(in_paths, variable, jets_name=jets_name)
-
-    # Setup the histogram
-    plot = HistogramPlot(
-        ylabel=f"Normalised Number of {jets_name}",
-        atlas_second_tag="$\\sqrt{s}=13$ TeV",
-        xlabel=variable,
-        bins=50,
-        y_scale=1.5,
-        logy=True,
-        norm=True,
-        bins_range=bins_range,
-    )
-
-    # Loop over the flavours and add them to the histogram
-    for label_value, label_string in enumerate([f.name for f in flavours]):
-        f"{label_string}jets" if len(label_string) == 1 else label_string
-
-        # Add the flavour with its label and colour to the histogram
-        plot.add(
-            Histogram(
-                df[df["flavour_label"] == label_value][variable],
-                label=flavour_cont[label_string].label,
-                colour=flavour_cont[label_string].colour,
-            )
-        )
-
-    # Draw the histogram
-    plot.draw()
-
-    # Set outdir and check that it exists
-    out_dir = Path(in_paths[0]).parent.parent / "plots"
-    out_dir.mkdir(exist_ok=True)
-
-    # Define output name and path and save the plot
-    fname = f"{stage}_{variable}"
-    out_path = out_dir / f"{fname}{suffix}.png"
-    plot.savefig(out_path)
-    log.info(f"Saved plot {out_path}")
-
-
-def make_hist_initial(
     stage: str,
     flavours: list,
     variable: str,
@@ -131,14 +22,15 @@ def make_hist_initial(
     jets_name: str = "jets",
     bins_range: tuple | None = None,
     suffix: str = "",
-    jets_to_plot: int = -1,
+    num_jets: int | None = -1,
     out_dir: Path | None = None,
     suffixes: list | None = None,
     out_format: str = "png",
+    batch_size: int = 10000,
 ) -> None:
-    """Make initial distribution plots.
+    """Make distribution plots of the reweighting variables.
 
-    Plot the initial distribution of the given variable
+    Plot the distribution of the given variable
     for multiple different samples (like ttbar, zpext, etc.)
     in one plot.
 
@@ -165,7 +57,7 @@ def make_hist_initial(
     suffix : str, optional
         A string suffix which is added to the plot
         output name, by default "".
-    jets_to_plot : int, optional
+    num_jets : int, optional
         Number of jets that are to be plotted per flavour,
         by default -1 (all).
     out_dir : Path object, optional
@@ -174,17 +66,29 @@ def make_hist_initial(
         Suffixes to mark the different samples, by default None
     out_format : str, optional
         Format of the output plot, by default "png".
+    batch_size : int, optional
+        Number of jets used per batch, by default 10000.
     """
+    # Get the correct name of the xlabel
+    if "pt" in variable:
+        xlabel = "Jet $p_\\mathrm{T}$ [GeV]"
+
+    elif "eta" in variable:
+        xlabel = "Jet $|\\eta|$"
+
+    else:
+        xlabel = variable
+
     # Setup the histogram
     plot = HistogramPlot(
         ylabel=f"Normalised Number of {jets_name}",
-        atlas_second_tag="$\\sqrt{s}=13$ TeV",
-        xlabel=variable,
-        bins=100,
+        xlabel=xlabel,
+        bins=50,
         y_scale=1.5,
         logy=True,
         norm=True,
         bins_range=bins_range,
+        underoverflow=False,
     )
 
     # Check that the given paths argument is a list
@@ -201,20 +105,33 @@ def make_hist_initial(
     # Loop over the different samples
     for i, in_paths in enumerate(in_paths_list):
         # Load jets from the file
-        reader = H5Reader(in_paths, batch_size=10000, jets_name=jets_name)
+        reader = H5Reader(fname=in_paths, batch_size=batch_size, jets_name=jets_name)
 
         # Loop over the flavours
-        for flavour in flavours:
+        for label_value, flavour in enumerate(flavours):
             (f"{flavour.label}jets" if len(flavour.label) == 1 else flavour.label)
+
+            if stage == "initial":
+                cuts = flavour.cuts
+
+            else:
+                cuts = Cuts.from_list([f"flavour_label == {label_value}"])
+
+            # Get the histo values
+            values = reader.load(
+                {jets_name: [variable]},
+                num_jets=num_jets,
+                cuts=cuts,
+            )[jets_name][variable]
+
+            # Check for pT values
+            if "pt" in variable:
+                values /= 1000
 
             # Add to histogram
             plot.add(
                 Histogram(
-                    reader.load(
-                        {jets_name: [variable]},
-                        num_jets=jets_to_plot,
-                        cuts=flavour.cuts,
-                    )[jets_name][variable],
+                    values=values,
                     label=flavour.label + " " + suffixes[i],
                     colour=flavour.colour,
                     linestyle=linestiles[i],
@@ -238,7 +155,7 @@ def make_hist_initial(
     log.info(f"Saved plot {out_path}")
 
 
-def plot_initial_resampling_dists(config) -> None:
+def plot_resampling_dists(config: PreprocessingConfig, stage: str) -> None:
     """Plot initial resampling dist plots.
 
     Plot the initial distribtions of the resampling variables
@@ -246,80 +163,46 @@ def plot_initial_resampling_dists(config) -> None:
 
     Parameters
     ----------
-    config : PreprocessingConfig object
+    config : PreprocessingConfig
         PreprocessingConfig object of the current preprocessing.
     """
-    # Get the paths of the samples
-    paths = [list(sample.path) for sample in config.components.samples]
+    # Get the paths/suffixes of the samples
+    if stage == "initial":
+        paths = [list(sample.path) for sample in config.components.samples]
+        suffixes = [sample.name for sample in config.components.samples]
 
-    # Get the suffixes of the samples
-    suffixes = [sample.name for sample in config.components.samples]
+    elif stage != "test" or config.merge_test_samples:
+        paths = [[config.out_fname]]
+        suffixes = None
 
-    # Loop over the resamling variables
-    for var in config.sampl_cfg.vars:
-        make_hist_initial(
-            stage="initial",
-            flavours=config.components.flavours,
-            variable=var,
-            in_paths_list=paths,
-            jets_name=config.jets_name,
-            jets_to_plot=100000,
-            out_dir=config.out_dir / "plots",
-            suffixes=suffixes,
-        )
-        if "pt" in var:
-            make_hist_initial(
-                stage="initial",
-                flavours=config.components.flavours,
-                variable=var,
-                in_paths_list=paths,
-                jets_name=config.jets_name,
-                bins_range=(0, 500e3),
-                suffix="low",
-                jets_to_plot=100000,
-                out_dir=config.out_dir / "plots",
-                suffixes=suffixes,
-            )
-
-
-def plot_resampled_dists(config, stage: str) -> None:
-    """Plot resampled variable distributions.
-
-    Plot the histograms of different variables at the
-    various stages of the preprocessing.
-
-    Parameters
-    ----------
-    config : PreprocessingConfig object
-        PreprocessingConfig object of the current preprocessing.
-    stage : str
-        Current stage of the preprocessing for which the plot is
-        made.
-    """
-    # Define special output names for the merge and test stage
-    if stage != "test" or config.merge_test_samples:
-        paths = [config.out_fname]
     else:
         paths = [path_append(config.out_fname, sample) for sample in config.components.samples]
+        suffixes = None
 
-    # Loop over the variables to plot them
+    # Loop over the resamling variables
     for var in config.sampl_cfg.vars:
         make_hist(
             stage=stage,
             flavours=config.components.flavours,
-            flavour_cont=config.flavour_cont,
             variable=var,
-            in_paths=paths,
+            in_paths_list=paths,
             jets_name=config.jets_name,
+            num_jets=config.num_jets_estimate_plotting,
+            out_dir=config.out_dir / "plots",
+            suffixes=suffixes,
+            batch_size=config.batch_size,
         )
         if "pt" in var:
             make_hist(
                 stage=stage,
                 flavours=config.components.flavours,
-                flavour_cont=config.flavour_cont,
                 variable=var,
-                in_paths=paths,
+                in_paths_list=paths,
                 jets_name=config.jets_name,
-                bins_range=(0, 500e3),
-                suffix="low",
+                bins_range=(20, 400),
+                suffix="_low",
+                num_jets=config.num_jets_estimate_plotting,
+                out_dir=config.out_dir / "plots",
+                suffixes=suffixes,
+                batch_size=config.batch_size,
             )


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Removes a lot of doubled plotting code
* Overall improved labels in the plots produced from the resampling variables

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
