### PR TITLE
Updating atlas-ftag-tools and puma versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
       - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
       - run: python -m pip install -e .[dev] # install in editable mode with additional development tools
+      - name: Install git gnupg python3-tk
+        run: apt update && apt install -y git gnupg python3-tk
       - name: Run tests
         run: pytest -v --junitxml=coverage.xml --cov-report=term-missing:skip-covered --cov=upp tests/
-      - name: Install git
-        run: apt update && apt install -y git gnupg
       - name: Report coverage with Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
       - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
       - run: python -m pip install -e .[dev] # install in editable mode with additional development tools
+      - name: Run tests
+        run: pytest -v --junitxml=coverage.xml --cov-report=term-missing:skip-covered --cov=upp umami-preprocessing/tests/
       - name: Install git
         run: apt update && apt install -y git gnupg
-      - name: Run tests
-        run: coverage run --source=upp -m pytest --show-capture=stdout
       - name: Report coverage with Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
       - run: python -m pip install -e .[dev] # install in editable mode with additional development tools
       - name: Run tests
-        run: pytest -v --junitxml=coverage.xml --cov-report=term-missing:skip-covered --cov=upp umami-preprocessing/tests/
+        run: pytest -v --junitxml=coverage.xml --cov-report=term-missing:skip-covered --cov=upp tests/
       - name: Install git
         run: apt update && apt install -y git gnupg
       - name: Report coverage with Codecov

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Updating atlas-ftag-tools and puma versions [#91](https://github.com/umami-hep/umami-preprocessing/pull/91)
 - Removing redundent plotting code / Making labels nicer [#89](https://github.com/umami-hep/umami-preprocessing/pull/89)
 
 ### [v0.2.3](https://github.com/umami-hep/umami-preprocessing/releases/tag/v0.2.3) (28.02.2025)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,22 +8,22 @@ requires-python = "<3.12,>=3.8"
 
 dependencies = [
     "pyyaml-include==1.3",
-    "PyYAML==6.0.1",
+    "PyYAML>=6.0.1",
     "rich==12.6.0",
-    "scipy==1.10.1",
-    "puma-hep==0.4.2",
-    "atlas-ftag-tools==0.2.8",
+    "scipy>=1.15.2",
+    "puma-hep==0.4.5",
+    "atlas-ftag-tools==0.2.10",
     "dotmap==1.3.30"
 ]
 
 [project.optional-dependencies]
 dev = [
-  "ruff==0.1.6",
-  "mypy==1.5.1",
+  "ruff==0.6.2",
+  "mypy==1.11.2",
   "pre-commit==3.5.0",
-  "pytest>=7.0.1",
+  "pytest>=7.2.2",
+  "pytest-cov>=4.0.0",
   "pytest-mock==3.11.1",
-  "pytest-cov>=3.0.0",
 ]
 
 [project.urls]

--- a/tests/unit/stages/test_plotting.py
+++ b/tests/unit/stages/test_plotting.py
@@ -27,7 +27,9 @@ class TestClass:
 
     def test_make_hist_initial(self):
         config = PreprocessingConfig.from_file(
-            Path("tests/integration/fixtures/test_config_pdf_auto.yaml"), "train"
+            Path(__file__).parent.parent.parent.resolve()
+            / Path("integration/fixtures/test_config_pdf_auto.yaml"),
+            "train",
         )
         make_hist(
             stage="initial",
@@ -38,7 +40,9 @@ class TestClass:
 
     def test_make_hist_initial_no_pt(self):
         config = PreprocessingConfig.from_file(
-            Path("tests/integration/fixtures/test_config_pdf_auto.yaml"), "train"
+            Path(__file__).parent.parent.parent.resolve()
+            / Path("integration/fixtures/test_config_pdf_auto.yaml"),
+            "train",
         )
         make_hist(
             stage="initial",


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Updating package versions (and dependencies) of `atlas-ftag-tools` (to v0.2.10) and `puma` (to v0.4.5)

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
