### PR TITLE
Improving logger to correctly detect HPC jobs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Improving logger to correctly detect HPC jobs [#94](https://github.com/umami-hep/umami-preprocessing/pull/94)
 - Updating atlas-ftag-tools and puma versions [#91](https://github.com/umami-hep/umami-preprocessing/pull/91)
 - Removing redundent plotting code / Making labels nicer [#89](https://github.com/umami-hep/umami-preprocessing/pull/89)
 


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Improving the logger to correctly detect and deactivate fancy terminal colours etc. in batch jobs.

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
