### PR TITLE
Rewrite Plotting Code to Enhance Speed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Rewrite Plotting Code to Enhance Speed [#96](https://github.com/umami-hep/umami-preprocessing/pull/96)
 - Add example config for open dataset [#92](https://github.com/umami-hep/umami-preprocessing/pull/92)
 - Adding GN3V01 Configs & renaming old Folder [#95](https://github.com/umami-hep/umami-preprocessing/pull/95)
 - Improving logger to correctly detect HPC jobs [#94](https://github.com/umami-hep/umami-preprocessing/pull/94)

--- a/tests/unit/stages/test_plotting.py
+++ b/tests/unit/stages/test_plotting.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 from ftag import get_mock_file
+from ftag.hdf5 import H5Reader
 
 from upp.classes.preprocessing_config import PreprocessingConfig
 from upp.stages.plot import make_hist
@@ -17,8 +18,37 @@ class TestClass:
 
     def setup_method(self, method):
         os.makedirs("tmp/upp-tests/integration/temp_workspace/ntuples", exist_ok=True)
-        self.generate_mock("tmp/upp-tests/integration/temp_workspace/ntuples/data1.h5")
-        self.generate_mock("tmp/upp-tests/integration/temp_workspace/ntuples/data2.h5")
+        self.fname1 = "tmp/upp-tests/integration/temp_workspace/ntuples/data1.h5"
+        self.fname2 = "tmp/upp-tests/integration/temp_workspace/ntuples/data2.h5"
+        self.generate_mock(out_file=self.fname1)
+        self.generate_mock(out_file=self.fname2)
+
+        # Get config
+        self.config = PreprocessingConfig.from_file(
+            Path(__file__).parent.parent.parent.resolve()
+            / Path("integration/fixtures/test_config_pdf_auto.yaml"),
+            "train",
+        )
+
+        # Get values dict
+        self.values_dict = {
+            "test": H5Reader(
+                fname=self.fname1,
+                batch_size=self.config.batch_size,
+                jets_name=self.config.jets_name,
+                shuffle=False,
+                equal_jets=True,
+            ).load(
+                {
+                    self.config.jets_name: [
+                        "pt",
+                        "abs_eta",
+                        "mass",
+                        "HadronConeExclTruthLabelID",
+                    ]
+                }
+            )[self.config.jets_name]
+        }
         print("setup_method      method:%s" % method.__name__)
 
     def teardown_method(self, method):
@@ -26,27 +56,21 @@ class TestClass:
         print("teardown_method   method:%s" % method.__name__)
 
     def test_make_hist_initial(self):
-        config = PreprocessingConfig.from_file(
-            Path(__file__).parent.parent.parent.resolve()
-            / Path("integration/fixtures/test_config_pdf_auto.yaml"),
-            "train",
-        )
+        """Run the make_hist for the inital pT distribution."""
         make_hist(
             stage="initial",
-            flavours=config.components.flavours,
-            variable=config.sampl_cfg.vars[0],
-            in_paths_list=["tmp/upp-tests/integration/temp_workspace/ntuples/data1.h5"],
+            values_dict=self.values_dict,
+            flavours=self.config.components.flavours,
+            variable=self.config.sampl_cfg.vars[0],
+            out_dir=Path("tmp/upp-tests/integration/temp_workspace/plots/"),
         )
 
     def test_make_hist_initial_no_pt(self):
-        config = PreprocessingConfig.from_file(
-            Path(__file__).parent.parent.parent.resolve()
-            / Path("integration/fixtures/test_config_pdf_auto.yaml"),
-            "train",
-        )
+        """Run the make_hist for the inital mass distribution."""
         make_hist(
             stage="initial",
-            flavours=config.components.flavours,
+            values_dict=self.values_dict,
+            flavours=self.config.components.flavours,
             variable="mass",
-            in_paths_list=["tmp/upp-tests/integration/temp_workspace/ntuples/data1.h5"],
+            out_dir=Path("tmp/upp-tests/integration/temp_workspace/plots/"),
         )


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Changing order of loading and plotting to only load the files once
* Using `num_jets_estimate` as total number of jets, not per flavour

The slow plotting came from the fact, that `num_jets_estimate` jets per flavour were loaded from file and the loading happened for multiple times, each for one variable. With this fix, the plotting of roughly 1M jets takes now 1:30 minutes.

Relates to the following issues

* Closes #57

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
