### PR TITLE
Enable Writing of Multiple Output Files in Merging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Enable Writing of Multiple Output Files in Merging [#97](https://github.com/umami-hep/umami-preprocessing/pull/97)
 - Rewrite Plotting Code to Enhance Speed [#96](https://github.com/umami-hep/umami-preprocessing/pull/96)
 - Add example config for open dataset [#92](https://github.com/umami-hep/umami-preprocessing/pull/92)
 - Adding GN3V01 Configs & renaming old Folder [#95](https://github.com/umami-hep/umami-preprocessing/pull/95)

--- a/tests/integration/fixtures/test_config_countup.yaml
+++ b/tests/integration/fixtures/test_config_countup.yaml
@@ -82,9 +82,10 @@ resampling:
 
 global:
   batch_size: 10_000
-  num_jets_estimate: 5000
+  num_jets_estimate: 5_000
   num_jets_estimate_norm: 100
   num_jets_estimate_available: -1
+  num_jets_per_output_file: 15_000
   base_dir: tmp/upp-tests/integration/temp_workspace/
   out_dir: test_out
   ntuple_dir: ntuples

--- a/tests/unit/stages/test_merging.py
+++ b/tests/unit/stages/test_merging.py
@@ -1,0 +1,190 @@
+"""
+Unit-tests (no disk IO) for upp.stages.merging.Merging.
+
+We monkey-patch upp.stages.merging.H5Writer with an in-memory stub so that
+_open_writer / write_chunk / write_components can be exercised without
+creating real HDF5 files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import numpy as np
+from ftag import Flavours
+
+import upp.stages.merging as merging_mod
+from upp.classes.preprocessing_config import PreprocessingConfig
+
+
+# Stub H5Writer that just records calls, does NO real IO
+class MemWriter:
+    def __init__(self, dst, dtypes, shapes, jets_name, **_):
+        self.dst = Path(dst)
+        self.dtypes = dtypes
+        self.shapes = shapes
+        self.num_jets = next(iter(shapes.values()))[0]
+        self.jets_name = jets_name
+        self.num_written = 0
+        self.attrs = {}
+
+    # API that Merging calls
+    def write(self, data: dict):
+        self.num_written += len(data[self.jets_name])
+
+    def close(self):
+        assert self.num_written == self.num_jets
+
+    def add_attr(self, name, value, *_):
+        self.attrs[name] = value
+
+
+# Minimal helpers to fabricate Components / Variables for unit tests
+def _jets_struct(n):
+    """Return a (n,) structured array with two float vars."""
+    dtype = np.dtype([("pt", "f4"), ("eta", "f4")])
+    rng = np.random.default_rng(42)
+    arr = np.empty(n, dtype=dtype)
+    arr["pt"] = rng.random(n)
+    arr["eta"] = rng.random(n)
+    return arr
+
+
+class DummyComponent(SimpleNamespace):
+    """Dummy component for testing.
+
+    Simulates the subset of the real Component interface that Merging uses:
+    - flavour
+    - stream  (generator of batches)
+    - num_jets
+    - complete flag
+    """
+
+    def __init__(self, flavour, jet_batches):
+        super().__init__()
+        self.flavour = Flavours[flavour]
+        self._batches = list(jet_batches)
+        self.num_jets = sum(len(b["jets"]) for b in self._batches)
+        self.complete = False
+        self.out_path = Path("/dev/null")
+
+    def setup_reader(self, *_args, **_kw):
+        pass
+
+    @property
+    def stream(self):
+        def _gen():
+            yield from self._batches
+
+        return _gen()
+
+
+def _minimal_merging(monkeypatch, jets_per_file=10) -> merging_mod.Merging:
+    """Create modded Merging version.
+
+    Return a fully-initialised Merging instance whose writer is the MemWriter
+    and whose config / variables are minimal SimpleNamespace objects.
+    """
+    # Patch H5Writer
+    monkeypatch.setattr(merging_mod, "H5Writer", MemWriter)
+
+    # Minimal Variables object
+    variables = SimpleNamespace(
+        variables=["jets"],
+        selectors={},
+        combined=lambda: {"jets": None},
+        keys=lambda: ["jets"],
+    )
+
+    # Setup cfg & components
+    cfg = SimpleNamespace(
+        components=SimpleNamespace(flavours=[Flavours["bjets"]]),
+        variables=variables,
+        batch_size=100,
+        jets_name="jets",
+        num_jets_per_output_file=jets_per_file,
+        file_tag="split",
+        out_fname=Path("/tmp/merged.h5"),
+        git_hash="deadbeef",
+        config={},
+        is_test=False,
+        merge_test_samples=False,
+    )
+
+    return merging_mod.Merging(cast(PreprocessingConfig, cfg))
+
+
+# Actual tests
+def test_add_jet_flavour_label(monkeypatch):
+    """A flavour label is added exactly once and matches the flavour list."""
+    merge = _minimal_merging(monkeypatch, jets_per_file=7)
+
+    jets = _jets_struct(5)
+    comp = SimpleNamespace(flavour=Flavours["bjets"])
+    tagged = merge.add_jet_flavour_label(jets, comp)
+
+    assert "flavour_label" in tagged.dtype.names
+    assert np.all(tagged["flavour_label"] == 0)
+
+    # Calling again must not duplicate the column
+    same = merge.add_jet_flavour_label(tagged, comp)
+    assert same.dtype == tagged.dtype
+
+
+def test_open_writer_names_and_shapes(monkeypatch):
+    """_open_writer should create a MemWriter with the correct dst name and shapes."""
+    merge = _minimal_merging(monkeypatch, jets_per_file=7)
+
+    # Minimal shapes / dtypes upfront
+    merge.base_shapes = {"jets": (42,)}
+    merge.dtypes = {"jets": _jets_struct(1).dtype}
+
+    merge._open_writer(
+        sample=None,
+        jets_in_file=7,
+        file_idx=0,
+        components=SimpleNamespace(unique_jets=True, jet_counts={}, dsids=[]),
+    )
+
+    writer = merge.writer
+    assert isinstance(writer, MemWriter)
+    assert writer.num_jets == 7
+    assert writer.dst.name.startswith("merged_split_000")
+    assert "flavour_label" in writer.attrs
+
+
+def test_write_chunk_splits(monkeypatch):
+    """Test split writing of write_chunk.
+
+    With num_jets_per_output_file=5 and a batch of 8 jets, write_chunk must
+    create two MemWriter instances and write all jets.
+    """
+    merge = _minimal_merging(monkeypatch, jets_per_file=5)
+
+    # Prepare internal bookkeeping identical to write_components()
+    jets1 = {"jets": _jets_struct(8)}
+    comp = DummyComponent("bjets", [jets1])
+    comps = [comp]
+
+    # Fake dtypes / shapes and open first writer
+    merge.dtypes = {"jets": jets1["jets"].dtype}
+    merge.base_shapes = {"jets": (8,)}
+    merge.total_jets = 8
+    merge._file_idx = 0
+    merge.jets_written = 0
+    merge.current_components = SimpleNamespace(unique_jets=True, jet_counts={}, dsids=[])
+    merge._sample = None
+
+    merge._open_writer(None, 5, 0, merge.current_components)
+
+    # Run write_chunk once
+    n_written = merge.write_chunk(comps)
+
+    # Assertions
+    assert n_written == 8
+
+    # First writer closed & second opened
+    assert merge._file_idx == 1
+    assert merge.writer.num_written == 3

--- a/upp/classes/preprocessing_config.py
+++ b/upp/classes/preprocessing_config.py
@@ -53,46 +53,56 @@ class PreprocessingConfig:
 
     Parameters
     ----------
+    config_path : Path
+        Path to the config yaml file that is used. Does not need to be set in config.
+    split : Split
+        For which part the preprocessing is run. Either train, val or test. This needs
+        to be set as a command line argument when running the programm. Does not need
+        to be set in config.
+    config : dict
+        Dict with the loaded config. Does not need to be set in config.
     base_dir : Path
         Base directory for all other paths.
-    ntuple_dir : Path
+    ntuple_dir : Path, optional
         Directory containing the input h5 ntuples. If a relative path is given, it is
-        interpreted as relative to base_dir.
-    components_dir : Path
+        interpreted as relative to base_dir. By default Path("ntuples")
+    components_dir : Path, optional
         Directory for intermediate component files. If a relative path is given, it is
-        interpreted as relative to base_dir.
-    out_dir : Path
+        interpreted as relative to base_dir. By default Path("components")
+    out_dir : Path, optional
         Directory for output files. If a relative path is given, it is interpreted as
-        relative to base_dir.
-    out_fname : Path
-        Filename stem for the output files.
-    batch_size : int
+        relative to base_dir. By default Path("output")
+    out_fname : Path, optional
+        Filename stem for the output files. By default Path("pp_output.h5")
+    batch_size : int, optional
         Batch size for the preprocessing. For each batch select
         `sampling_fraction*batch_size_after_cuts`. It is recommended to choose high batch sizes
         especially to the `countup` method to achive best agreement of target and resampled
-        distributions.
-    num_jets_estimate : int
+        distributions. By default 100_000
+    num_jets_estimate : int, optional
         Any of the further three arguments that are not specified will default to this value
         Is equal to 1_000_000 by default.
-    num_jets_estimate_available : int | None
+    num_jets_estimate_available : int, optional
         A sabsample taken from the whole sample to estimate the number of jets after the cuts.
         Please keep this number high in order to not get poisson error of more then 5%.
         If time allows you can use -1 to get a precise number of jets and not just an estimate
         although it will be slow for large datasets. Is equal to num_jets_estimate by default.
-    num_jets_estimate_hist : int
+    num_jets_estimate_hist : int, optional
         Number of jets of each flavour that are used to construct histograms for probability
         density function estimation. Larger numbers give a better quality estmate of the pdfs.
         Is equal to num_jets_estimate by default.
-    num_jets_estimate_norm : int
+    num_jets_estimate_norm : int, optional
         Number of jets of each flavour that are used to estimate shifting and scaling during
         normalisation step. Larger numbers give a better quality estmates.
         Is equal to num_jets_estimate by default.
-    num_jets_estimate_plotting : int
+    num_jets_estimate_plotting : int, optional
         Number of jets of each flavour used for plotting the initial and the final resampling
         variable distributions. Larger numbers give a better estimate of the full distributions.
         Is equal to num_jets_estimate by default.
-    jets_name : str
-        Name of the jets dataset in the input file.
+    merge_test_samples : bool, optional
+        Merge the test samples of the different processes into one file. By default False.
+    jets_name : str, optional
+        Name of the jets dataset in the input file. By default "jets".
     """
 
     config_path: Path
@@ -112,6 +122,7 @@ class PreprocessingConfig:
     merge_test_samples: bool = False
     jets_name: str = "jets"
     flavour_config: Path | None = None
+    num_jets_per_output_file: int | None = None
 
     def __post_init__(self):
         # postprocess paths

--- a/upp/stages/merging.py
+++ b/upp/stages/merging.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging as log
 from copy import copy
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -34,6 +35,8 @@ class Merging:
         self.jets_name = config.jets_name
         self.rng = np.random.default_rng(42)
         self.flavours = self.components.flavours
+        self.num_jets_per_output_file = config.num_jets_per_output_file
+        self.file_tag = "split"
 
     def add_jet_flavour_label(self, jets: np.ndarray, component: Component) -> np.ndarray:
         """Add the jet flavour label to the jets.
@@ -60,44 +63,104 @@ class Merging:
 
         return join_structured_arrays([jets, label_array])
 
-    def write_chunk(self, components: Components) -> int:
-        """Write chunk to file.
+    def _open_writer(
+        self,
+        sample: str | None,
+        jets_in_file: int,
+        file_idx: int,
+        components: Components,
+    ) -> None:
+        """Create `self.writer` for the next output file and attach all static attributes.
 
         Parameters
         ----------
-        components : Components
-            Components instance of all components that are written
+        sample
+            Sample name (``None`` for the "train/val test" merge).
+        jets_in_file
+            Capacity of the new file (= leading dimension of every dataset).
+        file_idx
+            Running part index (0, 1, 2, …); used only for the filename suffix.
+        components
+            The `Components` object we are currently merging needed for `jet_counts`, etc.
+        """
+        # Construct the filename
+        fname = Path(self.config.out_fname)
+
+        if sample:
+            fname = path_append(fname, sample)
+
+        if self.num_jets_per_output_file is not None:
+            suffix = f"{self.file_tag}_{file_idx:03d}"
+            fname = fname.with_name(f"{fname.stem}_{suffix}{fname.suffix}")
+
+        # Adjust shapes to the capacity of this file
+        shapes = {name: (jets_in_file,) + shape[1:] for name, shape in self.base_shapes.items()}
+
+        # Instantiate an H5Writer
+        self.writer = H5Writer(
+            fname,
+            self.dtypes,
+            shapes,
+            add_flavour_label=self.jets_name,
+            jets_name=self.jets_name,
+        )
+
+        # Copy the metadata attributes
+        self.writer.add_attr(
+            "flavour_label",
+            [f.name for f in self.flavours],
+            self.jets_name,
+        )
+        self.writer.add_attr("unique_jets", components.unique_jets)
+        self.writer.add_attr("jet_counts", json.dumps(components.jet_counts))
+        self.writer.add_attr("dsids", str(components.dsids))
+        self.writer.add_attr("config", json.dumps(self.config.config))
+        self.writer.add_attr("upp_hash", self.config.git_hash)
+
+        # Log for debugging
+        log.debug(f"Setup merge output at {self.writer.dst}")
+
+    def write_chunk(self, components: Components) -> int:
+        """Read one chunk, merge and write it to disk.
+
+        Read one batch from every active component, merge them and write
+        them to disk. If the batch does not fit into the current file it is
+        split across files transparently.
 
         Returns
         -------
         int
-            Number of jets written to file
+            The number of jets that were consumed from the components
+            (== written to disk).  When all components are exhausted the
+            function returns 0 so that the caller can stop its loop.
         """
-        merged = {}
+        # Init a merged dict
+        merged: dict[str, np.ndarray] = {}
+
+        # Loop over components
         for component in components:
             try:
-                # Shallow copy is needed since we add a variable
+                # shallow copy because we will add a field
                 batch = copy(next(component.stream))
                 batch[self.jets_name] = self.add_jet_flavour_label(
-                    jets=batch[self.jets_name],
-                    component=component,
+                    jets=batch[self.jets_name], component=component
                 )
-
             except StopIteration:
                 component.complete = True
 
             if component.complete:
                 continue
 
-            # Merge components
+            # Merge this component's arrays into the running dict
             for name, array in batch.items():
                 if name not in merged:
                     merged[name] = array
                 else:
                     merged[name] = np.concatenate([merged[name], array])
 
-        if all(component.complete for component in components):
-            return False
+        # Stop if there is nothing more to read
+        if all(c.complete for c in components):
+            return 0
 
         # Apply track selections
         for name in self.variables.variables:
@@ -106,13 +169,79 @@ class Merging:
             if selector := self.variables.selectors.get(name):
                 merged[name] = selector(merged[name])
 
-        # Write
-        self.writer.write(merged)
+        # Get the total length of jets from the batch and how much
+        # capacity is left in the file
+        merged_len = len(merged[self.jets_name])
+        capacity_left = self.writer.num_jets - self.writer.num_written
 
-        return len(merged[self.jets_name])
+        # Check if the capacity of the given file is already zero
+        if capacity_left == 0:
+            # close the filled file
+            self.writer.close()
 
-    def write_components(self, sample: str, components: Components) -> None:
-        # setup inputs
+            # open the next one
+            self._file_idx += 1
+            remaining_total = self.total_jets - self.jets_written
+
+            # Quit writing when no jets are left to write
+            if remaining_total == 0:
+                return 0
+
+            next_file_size = (
+                min(self.num_jets_per_output_file, remaining_total)
+                if self.num_jets_per_output_file
+                else remaining_total
+            )
+            self._open_writer(
+                self._sample,
+                next_file_size,
+                self._file_idx,
+                self.current_components,
+            )
+
+            # Recompute free space in the freshly-opened file
+            capacity_left = self.writer.num_jets - self.writer.num_written
+
+        # Check if the whole batch fits into the file
+        if merged_len <= capacity_left:
+            # whole batch fits
+            self.writer.write(merged)
+
+        else:
+            # Write the *head* that still fits into the present file
+            head = {n: a[:capacity_left] for n, a in merged.items()}
+            self.writer.write(head)
+            self.writer.close()
+
+            # Open a fresh file sized for the remaining jets
+            self._file_idx += 1
+            remaining_total = self.total_jets - (self.jets_written + capacity_left)
+            next_file_size = (
+                min(self.num_jets_per_output_file, remaining_total)
+                if self.num_jets_per_output_file
+                else remaining_total
+            )
+            self._open_writer(self._sample, next_file_size, self._file_idx, self.current_components)
+
+            # Write the *tail* that goes into the new file
+            tail = {n: a[capacity_left:] for n, a in merged.items()}
+            self.writer.write(tail)
+
+        # Updating the progress-bar
+        self.jets_written += merged_len
+        return merged_len
+
+    def write_components(self, sample: str | None, components: Components) -> None:
+        """
+        Merge *components* into one or more HDF5 files.
+
+        If ``self.num_jets_per_output_file`` is ``None`` the behaviour is identical to the
+        original implementation (exactly one output file).  Otherwise the function
+        keeps opening new `H5Writer`s whenever the current file reaches that jet
+        limit.  All heavy work (splitting batches, rolling files) is handled in
+        ``self.write_chunk``.
+        """
+        # Prepare every Component's reader
         for component in components:
             batch_size = self.batch_size * component.num_jets // components.num_jets + 1
             component.setup_reader(
@@ -126,26 +255,28 @@ class Merging:
             )
             component.complete = False
 
-        # setup outputs
-        fname = self.config.out_fname
-        if sample:
-            fname = path_append(fname, sample)
-        self.writer = H5Writer(
-            fname,
-            components[0].reader.dtypes(self.variables.combined()),
-            components[0].reader.shapes(components.num_jets, self.variables.keys()),
-            add_flavour_label=self.jets_name,
-            jets_name=self.jets_name,
-        )
-        self.writer.add_attr("flavour_label", [f.name for f in self.flavours], self.jets_name)
-        self.writer.add_attr("unique_jets", components.unique_jets)
-        self.writer.add_attr("jet_counts", json.dumps(components.jet_counts))
-        self.writer.add_attr("dsids", str(components.dsids))
-        self.writer.add_attr("config", json.dumps(self.config.config))
-        self.writer.add_attr("upp_hash", self.config.git_hash)
-        log.debug(f"Setup merge output at {self.writer.dst}")
+        # Cache dtype / base shapes once (re-used for every new file)
+        self.dtypes = components[0].reader.dtypes(self.variables.combined())
+        self.base_shapes = components[0].reader.shapes(components.num_jets, self.variables.keys())
 
-        # Write
+        # Bookkeeping shared with write_chunk
+        self.total_jets = components.num_jets
+        self.jets_written = 0
+        self._file_idx = 0
+        self._sample = sample
+        self.current_components = components
+
+        # decide capacity of the first file
+        first_file_size = (
+            min(self.num_jets_per_output_file, self.total_jets)
+            if self.num_jets_per_output_file
+            else self.total_jets
+        )
+
+        # Open the first output file
+        self._open_writer(sample, first_file_size, self._file_idx, components)
+
+        # Main merge loop (progress bar unchanged)
         with ProgressBar() as progress:
             task = progress.add_task(
                 f"[green]Merging {components.num_jets:,} jets...",
@@ -157,10 +288,10 @@ class Merging:
                     break
                 progress.update(task, advance=n)
 
+        # Close Writer
         self.writer.close()
-        sample = "merged" if sample is None else sample
-        log.info(f"[bold green]Finished merging {components.num_jets:,} {sample} jets!")
-        log.info(f"[bold green]Saved to {fname}")
+        label = "merged" if sample is None else sample
+        log.info(f"[bold green]Finished merging {components.num_jets:,} {label} jets!")
 
     def run(self):
         """Run merging of the components."""

--- a/upp/stages/normalisation.py
+++ b/upp/stages/normalisation.py
@@ -241,14 +241,21 @@ class Normalisation:
         title = " Computing Normalisations "
         log.info(f"[bold green]{title:-^100}")
 
+        # Get the correct output names if multiple output files were written
+        if self.config.num_jets_per_output_file:
+            fname = self.config.out_fname.parent / f"{self.config.out_fname.stem}*.h5"
+
+        else:
+            fname = self.config.out_fname
+
         # Setup reader
         reader = H5Reader(
-            self.config.out_fname,
+            fname,
             self.config.batch_size,
             precision="full",
             jets_name=self.jets_name,
         )
-        log.debug(f"Setup reader at: {self.config.out_fname}")
+        log.debug(f"Setup reader at: {fname}")
 
         norm_dict = None
         class_dict = None

--- a/upp/stages/plot.py
+++ b/upp/stages/plot.py
@@ -139,7 +139,15 @@ def plot_resampling_dists(config: PreprocessingConfig, stage: str) -> None:
             vars_to_load += list(set(iter_flav.cuts.variables))
 
     elif stage != "test" or config.merge_test_samples:
-        paths = [[config.out_fname]]
+        paths = [
+            [
+                (
+                    config.out_fname.parent / f"{config.out_fname.stem}*.h5"
+                    if config.num_jets_per_output_file
+                    else config.out_fname
+                )
+            ]
+        ]
         suffixes = ["" for _ in paths]
         vars_to_load += ["flavour_label"]
 


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Introducing the `num_jets_per_output_file` option in the config
* When non `None`, this is the number of jets written to a single output file before a new one is opened.
* Allows to make a lot of smaller files which is easier to distribute and can still be loaded as one thanks to the virtual datasets of atlas-ftag-tools

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
