### PR TITLE
Update atlas-ftag-tools and puma

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Update atlas-ftag-tools and puma [#101](https://github.com/umami-hep/umami-preprocessing/pull/101)
 - Fix bug where num jets is not passed to the writer + version updates [#99](https://github.com/umami-hep/umami-preprocessing/pull/99/)
 - updated pre-processing configs for upgrade [#98](https://github.com/umami-hep/umami-preprocessing/pull/98)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = "<3.12,>=3.8"
 
 dependencies = [
     "atlas-ftag-tools==0.2.13",
-    "dotmap==1.3.30"
+    "dotmap==1.3.30",
     "puma-hep==0.4.8",
     "pyyaml-include==1.3",
     "PyYAML>=6.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,23 +7,23 @@ readme = "README.md"
 requires-python = "<3.12,>=3.8"
 
 dependencies = [
+    "atlas-ftag-tools==0.2.13",
+    "dotmap==1.3.30"
+    "puma-hep==0.4.8",
     "pyyaml-include==1.3",
     "PyYAML>=6.0.1",
     "rich==12.6.0",
     "scipy>=1.15.2",
-    "puma-hep==0.4.7",
-    "atlas-ftag-tools==0.2.12",
-    "dotmap==1.3.30"
 ]
 
 [project.optional-dependencies]
 dev = [
-  "ruff==0.6.2",
   "mypy==1.11.2",
   "pre-commit==3.5.0",
-  "pytest>=7.2.2",
   "pytest-cov>=4.0.0",
   "pytest-mock==3.11.1",
+  "pytest>=7.2.2",
+  "ruff==0.6.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Bump `atlas-ftag-tools` to version `v0.2.13`
* Bump `puma` to version `v0.4.8`

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
