### PR TITLE
Updating underlying ATLAS packages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Updating underlying ATLAS packages [#103](https://github.com/umami-hep/umami-preprocessing/pull/103)
 - Update atlas-ftag-tools and puma [#101](https://github.com/umami-hep/umami-preprocessing/pull/101)
 - Fix bug where num jets is not passed to the writer + version updates [#99](https://github.com/umami-hep/umami-preprocessing/pull/99/)
 - updated pre-processing configs for upgrade [#98](https://github.com/umami-hep/umami-preprocessing/pull/98)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,13 @@ readme = "README.md"
 requires-python = "<3.12,>=3.8"
 
 dependencies = [
-    "atlas-ftag-tools==0.2.13",
-    "dotmap==1.3.30",
-    "puma-hep==0.4.8",
-    "pyyaml-include==1.3",
-    "PyYAML>=6.0.1",
-    "rich==12.6.0",
-    "scipy>=1.15.2",
+  "atlas-ftag-tools==0.2.14",
+  "dotmap==1.3.30",
+  "puma-hep==0.4.9",
+  "pyyaml-include==1.3",
+  "PyYAML>=6.0.1",
+  "rich==12.6.0",
+  "scipy>=1.15.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Updating `atlas-ftag-tools` to [`v0.2.14`](https://github.com/umami-hep/atlas-ftag-tools/releases/tag/v0.2.14)
* Updating `puma-hep` to [`v0.4.9`](https://github.com/umami-hep/puma/releases/tag/v0.4.9)

Tagging @theresa-reisch

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
