### PR TITLE
Allow python up to 3.14.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{name="Alexander Froch"}]
 dynamic = ["version"]
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.10,<3.15"
 
 dependencies = [
   "atlas-ftag-tools==0.3.1",


### PR DESCRIPTION
## Summary

Allow to have Python version up to `3.14.*`.

Depends on `atlas-ftag-tools` PR [#150](https://github.com/umami-hep/atlas-ftag-tools/pull/150)

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
