### PR TITLE
Modified resampling error checking when no resampling is applied

### DIFF
--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -502,11 +502,12 @@ class Resampling:
                 f" {self.config.sampling_fraction}..."
             )
             frac = iter_component.sampling_fraction if self.select_func else 1
-            iter_component.check_num_jets(
-                iter_component.num_jets,
-                sampling_fraction=frac,
-                cuts=iter_component.cuts,
-            )
+            if self.select_func:
+                iter_component.check_num_jets(
+                    iter_component.num_jets,
+                    sampling_fraction=frac,
+                    cuts=iter_component.cuts,
+                )
 
         # Create check variable to ensure at least one region was processed
         region_processed = not region

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -277,12 +277,22 @@ class Resampling:
             if all(component._complete for component in components):
                 break
 
-        # If one component couldn't be completed, raise ValueError
+        # If one component couldn't be completed, raise ValueError if resampling is not None
         for component in components:
-            if not component._complete:
+            if not component._complete and self.select_func:
                 raise ValueError(
                     f"Ran out of {component} jets after writing {component.writer.num_written:,}"
                 )
+            elif not component._complete:
+                log.warning(
+                    f"Ran out of {component} jets after writing {component.writer.num_written:,}, continuing with maximum available number since 
+                    resampling is disabled!"
+                )
+                component._ups_ratio = component.writer.num_written / component._unique_jets
+                component.writer.add_attr("upsampling_ratio", component._ups_ratio)
+                component.writer.add_attr("unique_jets", component._unique_jets)
+                component.writer.add_attr("dsid", str(component.sample.dsid))
+                component.writer.close()
 
     def run_on_region(
         self,


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Circumvents check_num_jets in resampling when resampling method is `None` to allow for running UPP with a non specified maximum number of jets

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
