### PR TITLE
Vectorize _assign_weights (~14x speedup) and fix rw_merge output filename bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Vectorize `_assign_weights` in rw_merge for ~14x speedup and fix hardcoded "train" in output filenames [#123](https://github.com/umami-hep/umami-preprocessing/pull/123)
 - Allow reweighting number of jets estimate to be larger than the minority class count [#122](https://github.com/umami-hep/umami-preprocessing/pull/122)
 - Add campaign year reweighting/resampling to Xbb configs [#118](https://github.com/umami-hep/umami-preprocessing/pull/118)
 

--- a/tests/unit/stages/test_rw_merge.py
+++ b/tests/unit/stages/test_rw_merge.py
@@ -1,8 +1,6 @@
-"""Unit tests for RWMerge._assign_weights vectorized implementation."""
+"""Unit tests for RWMerge._assign_weights."""
 
 from __future__ import annotations
-
-import time
 
 import numpy as np
 import pytest
@@ -14,49 +12,40 @@ def _make_rw_data(n_classes=3, n_bins_per_dim=10, n_dims=2):
     """Create synthetic reweighting data for testing."""
     shape = tuple([n_bins_per_dim] * n_dims)
     rw = {
-        "weights": {
-            str(c): np.random.rand(*shape).astype(np.float64) for c in range(n_classes)
-        },
+        "weights": {str(c): np.random.rand(*shape).astype(np.float64) for c in range(n_classes)},
     }
     return rw
 
 
-def _assign_weights_original(this_rw, bins, to_dump):
-    """Original per-jet loop implementation for comparison."""
-    this_weights = np.zeros(to_dump.shape, dtype=float)
-    for i in range(this_weights.shape[0]):
-        bin_idx = bins[:, i]
-        cls = to_dump[i]
-        thishist = this_rw["weights"][str(cls)][tuple(bin_idx)]
-        this_weights[i] = thishist
-    return this_weights
-
-
-class TestAssignWeightsCorrectness:
-    """Verify vectorized _assign_weights matches the original loop."""
+class TestAssignWeights:
+    """Verify _assign_weights produces correct per-jet weights from histogram lookup."""
 
     @pytest.mark.parametrize("n_jets", [1, 10, 100, 1000])
     @pytest.mark.parametrize("n_dims", [1, 2, 3])
-    def test_matches_original(self, n_jets, n_dims):
+    def test_correct_lookup(self, n_jets, n_dims):
+        """Each jet's weight should match the histogram value at its bin and class."""
         n_classes = 4
         n_bins = 8
         rw = _make_rw_data(n_classes=n_classes, n_bins_per_dim=n_bins, n_dims=n_dims)
         bins = np.random.randint(0, n_bins, size=(n_dims, n_jets))
         classes = np.random.randint(0, n_classes, size=n_jets)
 
-        expected = _assign_weights_original(rw, bins, classes)
         result = RWMerge._assign_weights(rw, bins, classes)
 
-        np.testing.assert_array_equal(result, expected)
+        # Verify each weight matches the histogram value
+        for i in range(n_jets):
+            expected = rw["weights"][str(classes[i])][tuple(bins[:, i])]
+            assert result[i] == expected, f"Mismatch at jet {i}"
 
     def test_single_class(self):
         rw = _make_rw_data(n_classes=1, n_bins_per_dim=5, n_dims=2)
         bins = np.random.randint(0, 5, size=(2, 50))
         classes = np.zeros(50, dtype=int)
 
-        expected = _assign_weights_original(rw, bins, classes)
         result = RWMerge._assign_weights(rw, bins, classes)
-        np.testing.assert_array_equal(result, expected)
+
+        for i in range(50):
+            assert result[i] == rw["weights"]["0"][tuple(bins[:, i])]
 
     def test_empty_input(self):
         rw = _make_rw_data(n_classes=3, n_bins_per_dim=5, n_dims=2)
@@ -65,42 +54,3 @@ class TestAssignWeightsCorrectness:
 
         result = RWMerge._assign_weights(rw, bins, classes)
         assert result.shape == (0,)
-
-
-class TestAssignWeightsPerformance:
-    """Benchmark vectorized vs original implementation."""
-
-    @pytest.mark.parametrize("n_jets", [10_000, 100_000, 250_000])
-    def test_vectorized_faster(self, n_jets):
-        n_classes = 5
-        n_bins = 15
-        n_dims = 2
-        rw = _make_rw_data(n_classes=n_classes, n_bins_per_dim=n_bins, n_dims=n_dims)
-        bins = np.random.randint(0, n_bins, size=(n_dims, n_jets))
-        classes = np.random.randint(0, n_classes, size=n_jets)
-
-        # Warm up
-        _assign_weights_original(rw, bins[:, :100], classes[:100])
-        RWMerge._assign_weights(rw, bins[:, :100], classes[:100])
-
-        # Time original
-        t0 = time.perf_counter()
-        expected = _assign_weights_original(rw, bins, classes)
-        t_original = time.perf_counter() - t0
-
-        # Time vectorized
-        t0 = time.perf_counter()
-        result = RWMerge._assign_weights(rw, bins, classes)
-        t_vectorized = time.perf_counter() - t0
-
-        np.testing.assert_array_equal(result, expected)
-
-        speedup = t_original / t_vectorized
-        print(
-            f"\n  n_jets={n_jets:>7,}: "
-            f"original={t_original:.4f}s, vectorized={t_vectorized:.4f}s, "
-            f"speedup={speedup:.1f}x"
-        )
-        # Vectorized should be significantly faster for large batches
-        if n_jets >= 100_000:
-            assert speedup > 5, f"Expected >5x speedup, got {speedup:.1f}x"

--- a/tests/unit/stages/test_rw_merge.py
+++ b/tests/unit/stages/test_rw_merge.py
@@ -1,0 +1,106 @@
+"""Unit tests for RWMerge._assign_weights vectorized implementation."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from upp.stages.rw_merge import RWMerge
+
+
+def _make_rw_data(n_classes=3, n_bins_per_dim=10, n_dims=2):
+    """Create synthetic reweighting data for testing."""
+    shape = tuple([n_bins_per_dim] * n_dims)
+    rw = {
+        "weights": {
+            str(c): np.random.rand(*shape).astype(np.float64) for c in range(n_classes)
+        },
+    }
+    return rw
+
+
+def _assign_weights_original(this_rw, bins, to_dump):
+    """Original per-jet loop implementation for comparison."""
+    this_weights = np.zeros(to_dump.shape, dtype=float)
+    for i in range(this_weights.shape[0]):
+        bin_idx = bins[:, i]
+        cls = to_dump[i]
+        thishist = this_rw["weights"][str(cls)][tuple(bin_idx)]
+        this_weights[i] = thishist
+    return this_weights
+
+
+class TestAssignWeightsCorrectness:
+    """Verify vectorized _assign_weights matches the original loop."""
+
+    @pytest.mark.parametrize("n_jets", [1, 10, 100, 1000])
+    @pytest.mark.parametrize("n_dims", [1, 2, 3])
+    def test_matches_original(self, n_jets, n_dims):
+        n_classes = 4
+        n_bins = 8
+        rw = _make_rw_data(n_classes=n_classes, n_bins_per_dim=n_bins, n_dims=n_dims)
+        bins = np.random.randint(0, n_bins, size=(n_dims, n_jets))
+        classes = np.random.randint(0, n_classes, size=n_jets)
+
+        expected = _assign_weights_original(rw, bins, classes)
+        result = RWMerge._assign_weights(rw, bins, classes)
+
+        np.testing.assert_array_equal(result, expected)
+
+    def test_single_class(self):
+        rw = _make_rw_data(n_classes=1, n_bins_per_dim=5, n_dims=2)
+        bins = np.random.randint(0, 5, size=(2, 50))
+        classes = np.zeros(50, dtype=int)
+
+        expected = _assign_weights_original(rw, bins, classes)
+        result = RWMerge._assign_weights(rw, bins, classes)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_empty_input(self):
+        rw = _make_rw_data(n_classes=3, n_bins_per_dim=5, n_dims=2)
+        bins = np.zeros((2, 0), dtype=int)
+        classes = np.zeros(0, dtype=int)
+
+        result = RWMerge._assign_weights(rw, bins, classes)
+        assert result.shape == (0,)
+
+
+class TestAssignWeightsPerformance:
+    """Benchmark vectorized vs original implementation."""
+
+    @pytest.mark.parametrize("n_jets", [10_000, 100_000, 250_000])
+    def test_vectorized_faster(self, n_jets):
+        n_classes = 5
+        n_bins = 15
+        n_dims = 2
+        rw = _make_rw_data(n_classes=n_classes, n_bins_per_dim=n_bins, n_dims=n_dims)
+        bins = np.random.randint(0, n_bins, size=(n_dims, n_jets))
+        classes = np.random.randint(0, n_classes, size=n_jets)
+
+        # Warm up
+        _assign_weights_original(rw, bins[:, :100], classes[:100])
+        RWMerge._assign_weights(rw, bins[:, :100], classes[:100])
+
+        # Time original
+        t0 = time.perf_counter()
+        expected = _assign_weights_original(rw, bins, classes)
+        t_original = time.perf_counter() - t0
+
+        # Time vectorized
+        t0 = time.perf_counter()
+        result = RWMerge._assign_weights(rw, bins, classes)
+        t_vectorized = time.perf_counter() - t0
+
+        np.testing.assert_array_equal(result, expected)
+
+        speedup = t_original / t_vectorized
+        print(
+            f"\n  n_jets={n_jets:>7,}: "
+            f"original={t_original:.4f}s, vectorized={t_vectorized:.4f}s, "
+            f"speedup={speedup:.1f}x"
+        )
+        # Vectorized should be significantly faster for large batches
+        if n_jets >= 100_000:
+            assert speedup > 5, f"Expected >5x speedup, got {speedup:.1f}x"

--- a/upp/stages/rw_merge.py
+++ b/upp/stages/rw_merge.py
@@ -87,7 +87,7 @@ class RWMerge:
             args_list.append(
                 (
                     reader_kwargs,
-                    output_dir / f"pp_output_train-full_{i}.h5",
+                    output_dir / f"pp_output_{self.config.split}-full_{i}.h5",
                     weights,
                     num_jets_per_flavours,
                     variables,

--- a/upp/stages/rw_merge.py
+++ b/upp/stages/rw_merge.py
@@ -169,8 +169,6 @@ class RWMerge:
                     bins = np.expand_dims(bins, axis=0)
 
                 try:
-                    # Note - I tried vectorising this but its not the bottleneck so
-                    # I'm leaving it as is
                     this_weights = RWMerge._assign_weights(rw, bins, to_dump[class_var])
 
                 except Exception:

--- a/upp/stages/rw_merge.py
+++ b/upp/stages/rw_merge.py
@@ -113,15 +113,11 @@ class RWMerge:
     @staticmethod
     def _assign_weights(this_rw, bins, to_dump):
         this_weights = np.zeros(to_dump.shape, dtype=float)
-
-        # This is SUPER slow - as we iterate each object, but its
-        for i in range(this_weights.shape[0]):
-            bin_idx = bins[:, i]
-
-            cls = to_dump[i]
-
-            thishist = this_rw["weights"][str(cls)][tuple(bin_idx)]
-            this_weights[i] = thishist
+        unique_classes = np.unique(to_dump)
+        for cls in unique_classes:
+            cls_mask = to_dump == cls
+            cls_bins = bins[:, cls_mask]
+            this_weights[cls_mask] = this_rw["weights"][str(cls)][tuple(cls_bins)]
         return this_weights
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Replaces the per-jet Python loop in `RWMerge._assign_weights()` with vectorized numpy advanced indexing — **~14x speedup**
- Fixes bug where `rw_merge` output files were hardcoded to `pp_output_train-full_{i}.h5` regardless of the actual split (val/test). Now uses `config.split`.
- Added changelog entry

## Benchmark results
```
    n_jets     original   vectorized    speedup
--------------------------------------------------
    10,000     0.0055s    0.0005s         12x
   100,000     0.0521s    0.0037s         14x
   250,000     0.1316s    0.0089s         15x
```

## Test plan
- [x] Added `tests/unit/stages/test_rw_merge.py` with correctness tests (parametrized over 1-3 dims, 1-1000 jets)
- [x] All 87 existing tests pass (including integration RW tests)
- [x] Pre-commit (ruff, ruff-format, mypy, pydoclint) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)