### PR TITLE
Update docs CI and supported Python docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,8 @@
 name: docs
 on:
+  pull_request:
+    branches:
+      - "*"
   push:
     branches:
       - main
@@ -14,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: "3.11"
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v3
         with:
@@ -23,4 +26,6 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install -r docs/requirements.txt
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs build --strict
+      - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: mkdocs gh-deploy --force

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: "3.11"
       - uses: pre-commit/action@v3.0.0
     # autofix
     #- uses: pre-commit-ci/lite-action@v1.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ If this is your first visit, please start with our detailed [Developer Guideline
 ## Quick start
 
 1. **Fork** the repository and clone it locally.
-2. Create and activate a Python ≥ 3.9 virtual environment (or conda env).
+2. Create and activate a Python 3.11 virtual environment (or conda env).
 3. Install the package *plus* development extras:
 
    ```bash
@@ -71,4 +71,3 @@ When in doubt, open an issue and tag the @umami-preprocessing‑maintainers.
 umami-preprocessing is released under the MIT license. By submitting code you agree that it can be distributed under the same terms.
 
 Happy coding — and may your $b$‑tagging be ever accurate! ✨
-

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Update docs and CI validation for supported Python versions [#TBD](https://github.com/umami-hep/umami-preprocessing/pull/TBD)
 - Update documentation [#124](https://github.com/umami-hep/umami-preprocessing/pull/124)
 - Vectorize `_assign_weights` in rw_merge for ~14x speedup and fix hardcoded "train" in output filenames [#123](https://github.com/umami-hep/umami-preprocessing/pull/123)
 - Allow reweighting number of jets estimate to be larger than the minority class count [#122](https://github.com/umami-hep/umami-preprocessing/pull/122)

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### [Latest]
 
-- Update docs and CI validation for supported Python versions [#TBD](https://github.com/umami-hep/umami-preprocessing/pull/TBD)
+- Update docs and CI validation for supported Python versions [#137](https://github.com/umami-hep/umami-preprocessing/pull/137)
 - Update documentation [#124](https://github.com/umami-hep/umami-preprocessing/pull/124)
 - Vectorize `_assign_weights` in rw_merge for ~14x speedup and fix hardcoded "train" in output filenames [#123](https://github.com/umami-hep/umami-preprocessing/pull/123)
 - Allow reweighting number of jets estimate to be larger than the minority class count [#122](https://github.com/umami-hep/umami-preprocessing/pull/122)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -182,10 +182,10 @@ For example:
 variables: !include xbb-variables.yaml
 ```
 
-One can also import variables configs already provided in this package `upp/config/` yaml files using just the yaml file name e.g.:
+One can also import variable configs already provided in this package under `upp/configs/` by using the yaml file name, e.g.:
 
 ```yaml
-variables: !include /<full path to your file>.yaml
+variables: !include variables.yaml
 ```
 
 ???info "You can choose later which variables in your output files are used for training"
@@ -242,4 +242,4 @@ resampling:
 
 ### Global Config 
 
-#### ::: upp.classes.preprocessing_config.PreprocessingConfig
+::: upp.classes.preprocessing_config.PreprocessingConfig

--- a/docs/reweighting.md
+++ b/docs/reweighting.md
@@ -29,7 +29,7 @@ The first stage takes each sample and splits it into its split and flavour compo
 
 To run the splitting, 
 ```
-python upp/main.py --config {config} --split-components [--container {single container} --files {files}]
+preprocess --config {config} --split-components [--container {single container} --files {files}]
 ```
 
 which will split the components. If `--container` is defined, then only that container from the config will be split. If this is not included, then all contains in the config will be split.
@@ -63,7 +63,7 @@ which will then automatically download, package up, and generate the meta data r
 
 ## Generate weights
 
-Once all the samples are prepared, we can calculate the weights. An example config can be found in `configs/GN3v01/GN3V01-RW.yaml`. We can look at the reweighting section:
+Once all the samples are prepared, we can calculate the weights. An example config can be found in `upp/configs/GN3V01/GN3V01-RW.yaml`. We can look at the reweighting section:
 
 
 ```yaml
@@ -111,7 +111,7 @@ Would calculate weights such that we have equivalent pt_frac distributions acros
 To run the reweighting simply do
 
 ```
-python upp/main.py --config {config} --rw
+preprocess --config {config} --rw
 ```
 
 ## Merging
@@ -119,11 +119,10 @@ python upp/main.py --config {config} --rw
 Finally, we can merge all the relevant jets with their weights. This is done by
 
 ```
-python upp/main.py --rwm --split {train/test/val}
+preprocess --config {config} --rwm --split {train/test/val}
 ```
 
 This can either work in series to create 1 single large file, or we can produce multiple files with multi-processing. To do this, ensure the `global` section of the pre-processing config includes `num_jets_per_output_file` and the `reweighting` section has `merge_num_proc>1`.
 This will then launch `merge_num_proc` processes, with approximately `num_jets_per_output_file` per file*.
 
 * Due to the nature of the H5Reader, the actual number of jets per file will be slightly smaller than what is requested, on the order of 0.1%.
-

--- a/docs/run.md
+++ b/docs/run.md
@@ -8,7 +8,7 @@ Before running UPP, make sure you have modified the configuration file according
 To run all preprocessing stages for the `train` split use:
 
 ```bash
-preprocess --config configs/test.yaml
+preprocess --config upp/configs/test.yaml
 ```
 
 For a comprehensive list of available flags, refer to `preprocess --help`.
@@ -24,7 +24,7 @@ By default, the train split contains 80% of the jets, while val and test contain
 If you want to preprocess the `val` or `test` split, use the `--split` argument:
 
 ```bash
-preprocess --config configs/config.yaml --split val
+preprocess --config path/to/config.yaml --split val
 ```
 
 You can also process `train`, `val`, and `test` with a single command using `--split=all`.
@@ -36,14 +36,14 @@ The preprocessing is broken up into several stages.
 To run with only specific stages enabled, include the flag for the required stages:
 
 ```bash
-preprocess --config configs/config.yaml --prep --resample
+preprocess --config path/to/config.yaml --prep --resample
 ```
 
 To run the whole chain excluding certain stages, include the corresponding negative flag (`--no-*`).
 For example to run without plotting
 
 ```bash
-preprocess --config configs/config.yaml --no-plot
+preprocess --config path/to/config.yaml --no-plot
 ```
 
 The stages are described below.
@@ -90,7 +90,7 @@ Afterwards, the prepare stage reads a specified number of jets (`num_jets_estima
     and finally the flavour that is used. In this case, `ghostsplitbjets`. The full name of the component is therefore: `lowpt_ttbar_ghostsplitbjets`. The full command would look like this:
 
     ```bash
-    preprocess --config configs/config.yaml --prep --component lowpt_ttbar_ghostsplitbjets
+    preprocess --config path/to/config.yaml --prep --component lowpt_ttbar_ghostsplitbjets
     ```
 
     It is hardly discouraged to run multiple steps with this option enabled. This option is mainly to parallelize the processing on HPCs. In addition, do not run this in the same job with multiple threads! h5py has access issues when the same file is read by multiple threads in the same job. Use multiple instances/jobs to run this.
@@ -106,7 +106,7 @@ You need to run the resampling stage even if you don't apply any resampling (e.g
     The command to run the specific region would look like this:
 
     ```bash
-    preprocess --config configs/config.yaml --resample --region lowpt
+    preprocess --config path/to/config.yaml --resample --region lowpt
     ```
 
     Similar to the `--prep` step, it is hardly discouraged to run multiple steps with this option enabled. This option is mainly to parallelize the processing on HPCs. Once all regions are resampled, you can continue with the following steps.
@@ -116,7 +116,7 @@ You need to run the resampling stage even if you don't apply any resampling (e.g
     The command to run the specific region would look like this:
 
     ```bash
-    preprocess --config configs/config.yaml --resample --region lowpt --component lowpt_ttbar_ghostsplitbjets
+    preprocess --config path/to/config.yaml --resample --region lowpt --component lowpt_ttbar_ghostsplitbjets
     ```
 
     Similar to the `--prep` step and the previous `--region` explanation, it is hardly discouraged to run multiple steps with this option enabled. This option is mainly to parallelize the processing on HPCs. Once all components from all regions are resampled, you can continue with the following steps. Furthermore, do not run this in the same job with multiple threads! h5py has access issues when the same file is read by multiple threads in the same job. Use multiple instances/jobs to run this.
@@ -143,4 +143,3 @@ check_input_samples --config_path <path/to/your/config>
 ```
 
 You can also add the `--deviation-factor`, which is by default `10.0` and the `--verbose` flags. The latter will print the number of initial jets to your terminal.
-

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -3,7 +3,7 @@ This guide will walk you through the process of setting up the Umami-Preprocessi
 ### Environment Setup
 
 Install UPP in a virtual environment to avoid conflicts with other software libraries.
-UPP requires Python 3.8 or later.
+UPP currently supports Python 3.10 and 3.11, with Python 3.11 recommended.
 
 === "conda"
 
@@ -30,7 +30,7 @@ UPP requires Python 3.8 or later.
 
     ```bash
     setupATLAS
-    lsetup "python 3.9.18-x86_64-el9"
+    lsetup "python 3.11.9-x86_64-el9"
     ```
 
     !!!info "You can also [set up conda on lxplus](https://abpcomputing.web.cern.ch/guides/python_inst/)"

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -33,7 +33,7 @@ plugins:
       handlers:
         python:
           options:
-            paths: [salt]
+            paths: [upp]
             line_length: 100
             show_root_heading: true
             show_root_toc_entry: true


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Aligns setup and contributor guidance with the supported Python range and recommends Python 3.11
* Pins docs and pre-commit CI to Python 3.11
* Builds documentation on pull requests while keeping deployment restricted to pushes to `main`
* Fixes stale documentation paths and MkDocs API configuration

Relates to the following issues

* Closes #127
* Closes #128
* Closes #131
* Closes #132
* Closes #133

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
