### PR TITLE
Sync pre-commit hooks and fix Ruff lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,26 @@
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.6.2"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.13.0"
     hooks:
       - id: ruff
         args: [--fix, --show-fixes, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.11.2"
+    rev: "v1.18.1"
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]
         additional_dependencies: ["types-requests", "types-PyYAML"]
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.32.0
+    rev: v1.37.1
     hooks:
       - id: yamllint
         args: ["-d", "{extends: relaxed, rules: {line-length: disable}}"]
 
   - repo: https://github.com/jsh9/pydoclint
-    rev: 0.6.6
+    rev: 0.7.3
     hooks:
       - id: pydoclint
         args: [--style=numpy]

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Sync pre-commit hooks and fix Ruff lint failures [#TBD](https://github.com/umami-hep/umami-preprocessing/pull/TBD)
 - Update documentation [#124](https://github.com/umami-hep/umami-preprocessing/pull/124)
 - Vectorize `_assign_weights` in rw_merge for ~14x speedup and fix hardcoded "train" in output filenames [#123](https://github.com/umami-hep/umami-preprocessing/pull/123)
 - Allow reweighting number of jets estimate to be larger than the minority class count [#122](https://github.com/umami-hep/umami-preprocessing/pull/122)

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### [Latest]
 
-- Sync pre-commit hooks and fix Ruff lint failures [#TBD](https://github.com/umami-hep/umami-preprocessing/pull/TBD)
+- Sync pre-commit hooks and fix Ruff lint failures [#138](https://github.com/umami-hep/umami-preprocessing/pull/138)
 - Update documentation [#124](https://github.com/umami-hep/umami-preprocessing/pull/124)
 - Vectorize `_assign_weights` in rw_merge for ~14x speedup and fix hardcoded "train" in output filenames [#123](https://github.com/umami-hep/umami-preprocessing/pull/123)
 - Allow reweighting number of jets estimate to be larger than the minority class count [#122](https://github.com/umami-hep/umami-preprocessing/pull/122)

--- a/tests/integration/test_run_rw.py
+++ b/tests/integration/test_run_rw.py
@@ -54,9 +54,9 @@ class TestRunRW:
         main(args)
         outpath = Path("tmp/upp-tests/integration/temp_workspace/split-components")
 
-        assert (
-            outpath / "organised-components.yaml"
-        ).exists(), "Organised components file not found"
+        assert (outpath / "organised-components.yaml").exists(), (
+            "Organised components file not found"
+        )
 
         for container in ["data1.h5", "data2.h5", "data3.h5"]:
             assert (outpath / container).exists()
@@ -117,9 +117,9 @@ class TestRunRW:
                 assert "jets" in f, "Expected 'jets' group in output file"
                 print("LOL", f.attrs, f["jets"].attrs, f["jets"].attrs.keys())
 
-                assert (
-                    "flavour_label" in f["jets"].attrs
-                ), "Expected 'flavour_label' attribute in 'jets' group of output file"
+                assert "flavour_label" in f["jets"].attrs, (
+                    "Expected 'flavour_label' attribute in 'jets' group of output file"
+                )
                 assert "flavour_label" in f["jets"].dtype.names
 
     def test_rw(self):

--- a/tests/unit/classes/test_preprocessing_config.py
+++ b/tests/unit/classes/test_preprocessing_config.py
@@ -73,7 +73,7 @@ class TestPreprocessingConfig(unittest.TestCase):
         # Valid cases
         self.assertEqual(
             str(config.get_file_name("resampled")),
-            "/tmp/upp-tests/integration/temp_workspace/" "test_out/pp_output_train.h5",
+            "/tmp/upp-tests/integration/temp_workspace/test_out/pp_output_train.h5",
         )
         self.assertEqual(
             str(config.get_file_name("resampled_scaled_shuffled")),

--- a/tests/unit/stages/test_plotting.py
+++ b/tests/unit/stages/test_plotting.py
@@ -13,7 +13,7 @@ from upp.stages.plot import make_hist
 
 class TestClass:
     def generate_mock(self, out_file, N=100):
-        fname, f = get_mock_file(num_jets=N, fname=out_file)
+        _fname, f = get_mock_file(num_jets=N, fname=out_file)
         f.close()
 
     def setup_method(self, method):

--- a/upp/classes/components.py
+++ b/upp/classes/components.py
@@ -313,9 +313,9 @@ class Components:
         component_list = []
         for component in config.config["components"]:
             # Ensure equal_jets flag is correctly set
-            assert (
-                "equal_jets" not in component
-            ), "equal_jets flag should be set in the sample config"
+            assert "equal_jets" not in component, (
+                "equal_jets flag should be set in the sample config"
+            )
 
             # Get the region cuts
             region_cuts = (

--- a/upp/grid/download_and_prepare.py
+++ b/upp/grid/download_and_prepare.py
@@ -121,9 +121,9 @@ def create_meta_data(
             ]
 
             vds = [f / "vds/vds.h5" for f in sel_containers]
-            assert all(
-                f.exists() for f in vds
-            ), f"Not all VDS files exist for {split} {flavour}. Found: {vds}"
+            assert all(f.exists() for f in vds), (
+                f"Not all VDS files exist for {split} {flavour}. Found: {vds}"
+            )
 
             files_by_component[split][flavour.name] = [str(f) for f in vds]
 

--- a/upp/stages/__init__.py
+++ b/upp/stages/__init__.py
@@ -10,17 +10,17 @@ from upp.stages.plot import make_hist, plot_resampling_dists
 from upp.stages.resampling import Resampling, safe_divide, select_batch
 
 __all__ = [
-    "bin_jets",
     "Hist",
+    "Merging",
+    "Normalisation",
+    "Resampling",
+    "bin_jets",
     "create_histograms",
+    "make_hist",
+    "plot_resampling_dists",
+    "safe_divide",
+    "select_batch",
     "subdivide_bins",
     "upscale_array",
     "upscale_array_regionally",
-    "Merging",
-    "Normalisation",
-    "make_hist",
-    "plot_resampling_dists",
-    "select_batch",
-    "safe_divide",
-    "Resampling",
 ]

--- a/upp/stages/merging.py
+++ b/upp/stages/merging.py
@@ -188,9 +188,7 @@ class Merging:
                 # All expected datasets that are present should match obs_len
                 for nm in expected_names:
                     if nm in f and f[nm].shape[0] != obs_len:
-                        log.warning(
-                            f"Dataset '{nm}' len={f[nm].shape[0]} " f"!= {obs_len} in {fname}"
-                        )
+                        log.warning(f"Dataset '{nm}' len={f[nm].shape[0]} != {obs_len} in {fname}")
                         return False
 
                 # Compare with expected rows for this part (if split mode)

--- a/upp/stages/resampling.py
+++ b/upp/stages/resampling.py
@@ -380,7 +380,7 @@ class Resampling:
             ):
                 log.info(
                     f"{component} usampling ratio is {np.mean(component._ups_ratio):.3f}, with"
-                    f" {component.num_jets/np.mean(component._ups_ratio):,.0f}/"
+                    f" {component.num_jets / np.mean(component._ups_ratio):,.0f}/"
                     f"{component.num_jets:,} unique jets."
                     f" Jets are upsampled at most {np.max(component._ups_max):.0f} times"
                 )

--- a/upp/stages/reweight.py
+++ b/upp/stages/reweight.py
@@ -20,15 +20,15 @@ class Reweight:
         self.config = config
         self.rw_config = config.rw_config
         self.flavours = [f.name for f in config.components.flavours]
-        assert (
-            self.rw_config is not None
-        ), "Reweighting configuration is not set in the preprocessing config"
+        assert self.rw_config is not None, (
+            "Reweighting configuration is not set in the preprocessing config"
+        )
         self.organised_components_config = (
             Path(config.base_dir) / "split-components/organised-components.yaml"
         )
-        assert (
-            self.organised_components_config.exists()
-        ), f"Organised components config file not found: {self.organised_components_config}"
+        assert self.organised_components_config.exists(), (
+            f"Organised components config file not found: {self.organised_components_config}"
+        )
 
     @property
     def hists_path(self):
@@ -90,9 +90,9 @@ class Reweight:
         print(f"Calculating weights for {len(reweights)} reweights")
         readers, per_reader_num_jets = self.get_input_readers()
         for reader in readers:
-            assert (
-                reader.batch_size == readers[0].batch_size
-            ), "All readers must have the same batch size"
+            assert reader.batch_size == readers[0].batch_size, (
+                "All readers must have the same batch size"
+            )
         batch_size_per_file = readers[0].batch_size
         all_vars = {}
         existing_vars = {}
@@ -174,7 +174,7 @@ class Reweight:
 
                 for cls in classes:
                     mask = data[rw.class_var] == cls
-                    hist, outbins = bin_jets(data[mask][rw.reweight_vars], rw.flat_bins)
+                    hist, _outbins = bin_jets(data[mask][rw.reweight_vars], rw.flat_bins)
                     if rw.class_var is not None:
                         cls = str(cls)
                     if rw_group not in all_histograms:

--- a/upp/stages/rw_merge.py
+++ b/upp/stages/rw_merge.py
@@ -30,9 +30,9 @@ class RWMerge:
         self.organised_components_config = (
             Path(config.base_dir) / "split-components/organised-components.yaml"
         )
-        assert (
-            self.organised_components_config.exists()
-        ), f"Organised components config file not found: {self.organised_components_config}"
+        assert self.organised_components_config.exists(), (
+            f"Organised components config file not found: {self.organised_components_config}"
+        )
 
         with open(self.organised_components_config) as f:
             organised_components = yaml.safe_load(f)

--- a/upp/stages/split_containers.py
+++ b/upp/stages/split_containers.py
@@ -189,7 +189,7 @@ class SplitContainers:
             assert all(
                 len(_flavour_label_by_component[component]) == 1 for component in sample_components
             ), f"Each component must have exactly 1 flavour label not {_flavour_label_by_component}"
-            flavour_label_by_component: dict[str, int] = {  # noqa: no-redef
+            flavour_label_by_component: dict[str, int] = {
                 component: _flavour_label_by_component[component][0]
                 for component in _flavour_label_by_component
             }

--- a/upp/utils/__init__.py
+++ b/upp/utils/__init__.py
@@ -6,7 +6,7 @@ from upp.utils.logger import ProgressBar, setup_logger
 from upp.utils.tools import path_append
 
 __all__ = [
-    "path_append",
     "ProgressBar",
+    "path_append",
     "setup_logger",
 ]


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Updates pre-commit hook revisions to match the current development tool versions
* Fixes the current Ruff lint failures on `main`
* Applies Ruff formatting to files that failed `ruff format --check`

Relates to the following issues

* Closes #129
* Closes #130

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
