### PR TITLE
Avoid reweighting runtime warnings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### [Latest]
 
-- Avoid expected divide warnings in reweighting weight calculation [#TBD](https://github.com/umami-hep/umami-preprocessing/pull/TBD)
+- Avoid expected divide warnings in reweighting weight calculation [#140](https://github.com/umami-hep/umami-preprocessing/pull/140)
 - Update documentation [#124](https://github.com/umami-hep/umami-preprocessing/pull/124)
 - Vectorize `_assign_weights` in rw_merge for ~14x speedup and fix hardcoded "train" in output filenames [#123](https://github.com/umami-hep/umami-preprocessing/pull/123)
 - Allow reweighting number of jets estimate to be larger than the minority class count [#122](https://github.com/umami-hep/umami-preprocessing/pull/122)

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Avoid expected divide warnings in reweighting weight calculation [#TBD](https://github.com/umami-hep/umami-preprocessing/pull/TBD)
 - Update documentation [#124](https://github.com/umami-hep/umami-preprocessing/pull/124)
 - Vectorize `_assign_weights` in rw_merge for ~14x speedup and fix hardcoded "train" in output filenames [#123](https://github.com/umami-hep/umami-preprocessing/pull/123)
 - Allow reweighting number of jets estimate to be larger than the minority class count [#122](https://github.com/umami-hep/umami-preprocessing/pull/122)

--- a/upp/stages/hist.py
+++ b/upp/stages/hist.py
@@ -41,8 +41,9 @@ def bin_jets(array: dict, bins: list) -> tuple[np.ndarray, np.ndarray]:
             bin in which this observation falls.  The representation depends on the
             `expand_binnumbers` argument.  See `Notes` for details.
     """
+    sample = s2u(array).astype(np.float64, copy=False)
     hist, _, out_bins = binned_statistic_dd(
-        sample=s2u(array),
+        sample=sample,
         values=None,
         statistic="count",
         bins=bins,

--- a/upp/stages/reweight.py
+++ b/upp/stages/reweight.py
@@ -273,9 +273,14 @@ class Reweight:
             idx_below_min = None
             for cls, hist in all_histograms[rw_group][rw_rep]["histograms"].items():
                 this_idx_below_min = hist == 0  # | (all_targets[rw_group][rw_rep] == 0)
-                output_weights[rw_group][rw_rep]["weights"][cls] = np.where(
-                    hist > 0, all_targets[rw_group][rw_rep] / hist, 0
+                weights = np.zeros_like(hist, dtype=float)
+                np.divide(
+                    all_targets[rw_group][rw_rep],
+                    hist,
+                    out=weights,
+                    where=hist > 0,
                 )
+                output_weights[rw_group][rw_rep]["weights"][cls] = weights
                 if idx_below_min is None:
                     idx_below_min = this_idx_below_min
                 else:


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Casts binning inputs to float64 before calling SciPy histogram binning
* Uses masked `np.divide` when calculating reweighting weights for zero-count bins
* Reduces the reweighting test output from runtime warnings to the remaining plotting warning only

Relates to the following issues

* Closes #136

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
