### PR TITLE
Update Python support and CI workflows

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,4 +1,7 @@
 name: Docker build
+concurrency:
+  group: ${{ github.workflow }}-${{ startsWith(github.ref, 'refs/tags/') && github.sha || (github.event.pull_request.number || github.ref) }}
+  cancel-in-progress: true
 
 on:
   pull_request:
@@ -20,10 +23,10 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build image
         run: docker build -f docker/Dockerfile --tag ${GITLAB_CONTAINER_REGISTRY}/upp:latest .
@@ -41,10 +44,10 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags')
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitLab container registry
         run: docker login gitlab-registry.cern.ch -u ${{ secrets.GITLAB_USERNAME }} -p ${{ secrets.GITLAB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,26 +1,30 @@
 name: docs
+concurrency:
+  group: ${{ github.workflow }}-${{ startsWith(github.ref, 'refs/tags/') && github.sha || (github.event.pull_request.number || github.ref) }}
+  cancel-in-progress: true
 on:
   push:
     branches:
       - main
+  workflow_dispatch:
 permissions:
   contents: write
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: 3.x
+          python-version: "3.11"
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install -r docs/requirements.txt
-      - run: mkdocs gh-deploy --force
+      - run: uv sync --extra dev && uv pip install -r docs/requirements.txt
+      - run: uv run mkdocs gh-deploy --force

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,7 @@
 name: pre-commit
+concurrency:
+  group: ${{ github.workflow }}-${{ startsWith(github.ref, 'refs/tags/') && github.sha || (github.event.pull_request.number || github.ref) }}
+  cancel-in-progress: true
 on:
   pull_request:
     branches:
@@ -6,16 +9,30 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   run:
+    name: pre-commit (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          python-version: 3.x
-      - uses: pre-commit/action@v3.0.0
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync --extra dev
+      - name: Cache pre-commit environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ matrix.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit
+        run: uv run pre-commit run --all-files
     # autofix
     #- uses: pre-commit-ci/lite-action@v1.0.1
     #  if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  pytest:
+  pytest_matrix:
     name: pytest (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
@@ -42,6 +42,18 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  pytest:
+    name: pytest
+    needs: [pytest_matrix]
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Check pytest matrix
+        run: |
+          if [ "${{ needs.pytest_matrix.result }}" != "success" ]; then
+            exit 1
+          fi
 
   publish:
     name: Publish to PyPI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,7 @@
 name: tests
+concurrency:
+  group: ${{ github.workflow }}-${{ startsWith(github.ref, 'refs/tags/') && github.sha || (github.event.pull_request.number || github.ref) }}
+  cancel-in-progress: true
 on:
   pull_request:
     branches:
@@ -8,23 +11,32 @@ on:
       - "main"
     tags:
       - "*"
+  workflow_dispatch:
 
 jobs:
   pytest:
-    name: pytest
+    name: pytest (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    container: python:3.11.10-slim-bookworm
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
       - run: echo "The ${{ github.repository }} repository has been cloned to the runner."
-      - run: python -m pip install -e .[dev] # install in editable mode with additional development tools
       - name: Install git gnupg python3-tk
-        run: apt update && apt install -y git gnupg python3-tk
+        run: sudo apt-get update && sudo apt-get install -y git gnupg python3-tk
+      - name: Install dependencies
+        run: uv sync --extra dev
       - name: Run tests
-        run: pytest -v --junitxml=coverage.xml --cov-report=term-missing:skip-covered --cov=upp tests/
+        run: uv run pytest -v --junitxml=coverage.xml --cov-report=term-missing:skip-covered --cov=upp tests/
       - name: Report coverage with Codecov
         uses: codecov/codecov-action@v4
         with:
@@ -41,12 +53,14 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v3
-      - name: Set up python version
-        uses: actions/setup-python@v4
+        uses: actions/checkout@v4
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - name: Sync environment
+        run: uv sync
       - name: Build package
-        run: |
-          python -m pip install -U pip build
-          python -m build
+        run: uv build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Update Python support and CI workflows [#141](https://github.com/umami-hep/umami-preprocessing/pull/141)
 - Update documentation [#124](https://github.com/umami-hep/umami-preprocessing/pull/124)
 - Vectorize `_assign_weights` in rw_merge for ~14x speedup and fix hardcoded "train" in output filenames [#123](https://github.com/umami-hep/umami-preprocessing/pull/123)
 - Allow reweighting number of jets estimate to be larger than the minority class count [#122](https://github.com/umami-hep/umami-preprocessing/pull/122)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [{name="Alexander Froch"}]
 dynamic = ["version"]
 license = {text = "MIT"}
 readme = "README.md"
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.11,<3.15"
 
 dependencies = [
   "atlas-ftag-tools==0.3.1",
@@ -52,6 +52,7 @@ requires = ["setuptools>=62"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
+target-version = "py311"
 lint.select = ["I", "E", "W", "F", "B", "UP", "ARG", "SIM", "TID", "RUF", "D2", "D3", "D4"]
 lint.ignore = ["RUF005"]
 line-length = 100


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Update supported Python versions to 3.11 through 3.14.
* Run tests and pre-commit across all supported Python versions.
* Refresh GitHub Actions versions, add workflow concurrency, and switch CI commands to uv.

Relates to the following issues

* None

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/umami-preprocessing/)