### PR TITLE
Update atlas-ftag-tools and puma

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Update atlas-ftag-tools and puma [#143](https://github.com/umami-hep/umami-preprocessing/pull/143)
 - Sync pre-commit hooks and fix Ruff lint failures [#138](https://github.com/umami-hep/umami-preprocessing/pull/138)
 - Update docs and CI validation for supported Python versions [#137](https://github.com/umami-hep/umami-preprocessing/pull/137)
 - Refresh Umami integration docs and CLI help text [#139](https://github.com/umami-hep/umami-preprocessing/pull/139)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,10 @@ readme = "README.md"
 requires-python = ">=3.11,<3.15"
 
 dependencies = [
-  "atlas-ftag-tools==0.3.1",
+  "atlas-ftag-tools==0.3.3",
   "dotmap>=1.3.30",
   "numpy>=2.2.6",
-  "puma-hep==0.5.1",
+  "puma-hep==0.5.2",
   "pyyaml-include==1.3",
   "PyYAML>=6.0.2",
   "rich>=14.1.0",


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Update `atlas-ftag-tools` to `v0.3.3`
* Update `puma` to `v0.5.2`

## Conformity
- [X] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [X] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
