### PR TITLE
Remove pytest-notebook dep, move dev to dependency-groups

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: uv sync --extra dev && uv pip install -r docs/requirements.txt
+      - run: uv sync && uv pip install -r docs/requirements.txt
       - run: uv run mkdocs build --strict
       - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: uv run mkdocs gh-deploy --force

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --all-extras
       - name: Cache pre-commit environments
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install git gnupg python3-tk
         run: sudo apt-get update && sudo apt-get install -y git gnupg python3-tk
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --all-extras
       - name: Run tests
         run: uv run pytest -v --junitxml=coverage.xml --cov-report=term-missing:skip-covered --cov=upp tests/
       - name: Report coverage with Codecov

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### [Latest]
 
+- Remove pytest-notebook dep, move dev to dependency-groups [#147](https://github.com/umami-hep/umami-preprocessing/pull/147)
 - Update Docker development image [#145](https://github.com/umami-hep/umami-preprocessing/pull/145)
 - Update atlas-ftag-tools and puma [#143](https://github.com/umami-hep/umami-preprocessing/pull/143)
 - Sync pre-commit hooks and fix Ruff lint failures [#138](https://github.com/umami-hep/umami-preprocessing/pull/138)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,13 @@ dependencies = [
   "scipy>=1.15.3",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
   "coverage>=7.10.6",
   "ipykernel>=6.30.1",
   "mypy>=1.18.1",
   "pre-commit>=4.3.0",
   "pydoclint>=0.7.3",
-  "pytest_notebook>=0.10.0",
   "pytest-cov>=7.0.0",
   "pytest-randomly>=4.0.1",
   "pytest>=8.4.2",


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Remove redundant `pytest-notebook` dependency
* Move `dev` dependencies to `[dependency-groups]`

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
