### PR TITLE
Fix license metadata and packaging cleanups

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync
       - name: Cache pre-commit environments
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install git gnupg python3-tk
         run: sudo apt-get update && sudo apt-get install -y git gnupg python3-tk
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync
       - name: Run tests
         run: uv run pytest -v --junitxml=coverage.xml --cov-report=term-missing:skip-covered --cov=upp tests/
       - name: Report coverage with Codecov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,6 @@ When in doubt, open an issue and tag the @umami-preprocessing‑maintainers.
 
 ## License and certificate of origin
 
-umami-preprocessing is released under the MIT license. By submitting code you agree that it can be distributed under the same terms.
+umami-preprocessing is released under the Apache 2.0 license. By submitting code you agree that it can be distributed under the same terms.
 
 Happy coding — and may your $b$‑tagging be ever accurate! ✨

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![codecov](https://codecov.io/gh/umami-hep/umami-preprocessing/graph/badge.svg?token=K8MJI20UZO)](https://codecov.io/gh/umami-hep/umami-preprocessing)
 [![PyPI version](https://badge.fury.io/py/umami-preprocessing.svg)](https://badge.fury.io/py/umami-preprocessing)
 [![docs](https://img.shields.io/badge/info-documentation-informational)](https://umami-hep.github.io/umami-preprocessing//)

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,7 @@
 
 ### [Latest]
 
-- Fix license metadata (Apache-2.0), add classifiers, fix dev install in CI/Docker
-
+- Fix license metadata and packaging cleanups [#152](https://github.com/umami-hep/umami-preprocessing/pull/152)
 - Update Puma Version [#149](https://github.com/umami-hep/umami-preprocessing/pull/149)
 - Remove pytest-notebook dep, move dev to dependency-groups [#147](https://github.com/umami-hep/umami-preprocessing/pull/147)
 - Update Docker development image [#145](https://github.com/umami-hep/umami-preprocessing/pull/145)

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Fix license metadata (Apache-2.0), add classifiers, fix dev install in CI/Docker
+
 - Remove pytest-notebook dep, move dev to dependency-groups [#147](https://github.com/umami-hep/umami-preprocessing/pull/147)
 - Update Docker development image [#145](https://github.com/umami-hep/umami-preprocessing/pull/145)
 - Update atlas-ftag-tools and puma [#143](https://github.com/umami-hep/umami-preprocessing/pull/143)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends git nano vim \
     && rm -rf /var/lib/apt/lists/*
 
-# copy and install package
+# copy and install package together with the dev dependency group (PEP 735)
 COPY . .
-RUN python -m pip install --no-cache-dir -e ".[dev]"
+RUN python -m pip install --no-cache-dir -e . \
+    && python -m pip install --no-cache-dir --group dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,20 @@ name = "umami-preprocessing"
 description = "ATLAS Flavour Tagging Preprocessing - Umami PreProcessing (UPP)"
 authors = [{name="Alexander Froch"}]
 dynamic = ["version"]
-license = {text = "MIT"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.11,<3.15"
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Science/Research",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Scientific/Engineering :: Physics",
+]
 
 dependencies = [
   "atlas-ftag-tools==0.3.3",
@@ -47,7 +58,7 @@ include-package-data = true
 version = {attr = "upp.__version__"}
 
 [build-system]
-requires = ["setuptools>=62"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* **Fix the license metadata.** `pyproject.toml` declared `license = {text = "MIT"}`, but the `LICENSE` file is Apache 2.0 (with CERN/ATLAS copyright). Correct it to the SPDX form `license = "Apache-2.0"`, declare `license-files = ["LICENSE"]`, and bump the build requirement to `setuptools>=77` for PEP 639 support. Also update the license statement in `CONTRIBUTING.md` and add a license badge to `README.md`
* Add PyPI `classifiers` (Python 3.11–3.14, intended audience, topic, dev status)
* Replace the no-op `uv sync --all-extras` with `uv sync` in `test.yml` and `pre-commit.yml` — dev dependencies live in the default `[dependency-groups]` table, so `--all-extras` installed nothing extra
* **Fix the dev image install.** `docker/Dockerfile` used `pip install -e ".[dev]"`, but the `dev` extra no longer exists (it moved to a PEP 735 dependency group); install it explicitly with `pip install --group dev`
* Swap the Black badge in `README.md` for a Ruff badge

Relates to the following issues

*

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/umami-preprocessing/)