### PR TITLE
Bump package version

### DIFF
--- a/upp/__init__.py
+++ b/upp/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = "v0.3.0"
+__version__ = "v0.3.1"
 
 from . import classes, stages, utils
 from .main import run_pp


### PR DESCRIPTION
@afroch now that the python versions acceptable for UPP have been bumped in https://github.com/umami-hep/umami-preprocessing/pull/141, we should bump the version and tag so we can push this to PyPI. This is needed to fix the issue being seen [here](https://gitlab.cern.ch/aft/algorithms/salt/-/work_items/85), you can't currently install salt with a python env >3.11 unless installing from source. There's a couple of Salt packages that need updated to allow up to 3.14 as well I think that can be updated after this

## Conformity
- [ ] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [ ] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
