### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/reweighting.md
+++ b/docs/reweighting.md
@@ -94,16 +94,16 @@ The reweighting can also be performed over track variables, for example
 
 ```yaml
 
-group: jets
-reweight_vars: [pt_frac]
-bins:
-    pt_frac:
-        [
-        [0, 0.5, 50],
-        [0.5, 1.0, 20]
-        ]
-class_var: ftagTruthOriginLabel
-class_target: mean
+- group: tracks
+  reweight_vars: [pt_frac]
+  bins:
+      pt_frac:
+          [
+          [0, 0.5, 50],
+          [0.5, 1.0, 20]
+          ]
+  class_var: ftagTruthOriginLabel
+  class_target: mean
 ```
 
 Would calculate weights such that we have equivalent pt_frac distributions across the track labels.


### PR DESCRIPTION
Updated reweighting example to fix a typo.

## Summary

This pull request introduces fixes a typo (jets -> tracks). No changelog entry is needed.

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
