### PR TITLE
Add container image documentation and generic Slurm submission scripts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### [Latest]
 
-- Add container image documentation and generic Slurm submission scripts with config-driven component enumeration [#XXX](https://github.com/umami-hep/umami-preprocessing/pull/XXX)
+- Add container image documentation and generic Slurm submission scripts with config-driven component enumeration [#160](https://github.com/umami-hep/umami-preprocessing/pull/160)
 
 ### [v0.3.1](https://github.com/umami-hep/umami-preprocessing/releases/tag/v0.3.1) (19.06.2026)
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### [Latest]
 
+- Add container image documentation and generic Slurm submission scripts with config-driven component enumeration [#XXX](https://github.com/umami-hep/umami-preprocessing/pull/XXX)
+
 ### [v0.3.1](https://github.com/umami-hep/umami-preprocessing/releases/tag/v0.3.1) (19.06.2026)
 
 - Make skip-resampling work end-to-end; support `num_jets: -1` to write all jets passing cuts, and record the resampling method in the output metadata [#153](https://github.com/umami-hep/umami-preprocessing/pull/153)

--- a/docs/hpc.md
+++ b/docs/hpc.md
@@ -1,0 +1,133 @@
+# Running on HPC clusters
+
+The preprocessing stages can be parallelized over components, regions and splits using the
+`--component`, `--region` and `--split` flags described in [Run](run.md). On a Slurm cluster, each
+of these units of work can run as its own batch job inside the [container image](setup.md#container-image).
+UPP ships a small set of submission scripts in `scripts/slurm/` that automate this.
+
+## Prerequisites
+
+- A cluster with Slurm and apptainer.
+- The UPP container image (see [Container image](setup.md#container-image)). By default the scripts
+  use `docker://gitlab-registry.cern.ch/aft/training-images/upp-images/upp:latest`. To avoid the
+  repeated `docker://` to SIF conversion in every job, pull the image once and point `UPP_IMAGE` at
+  the local file:
+
+  ```bash
+  apptainer pull upp_latest.sif docker://gitlab-registry.cern.ch/aft/training-images/upp-images/upp:latest
+  export UPP_IMAGE=/path/to/upp_latest.sif
+  ```
+
+## Interactive use
+
+For quick tests, run UPP inside the container on an interactive allocation:
+
+```bash
+salloc --ntasks 1 --cpus-per-task 4 --time 2:00:00
+srun apptainer exec --contain --pwd "$PWD" -B /home -B /tmp \
+    "$UPP_IMAGE" preprocess --config <path/to/config.yaml> --prep
+```
+
+## Batch submission scripts
+
+The `scripts/slurm/` directory contains three scripts:
+
+- `submit.sh` runs on the login node. It reads the components from your preprocessing config and
+  submits one Slurm job per unit of work via `sbatch`.
+- `batch.sh` is the sbatch payload. It carries the `#SBATCH` resource header and starts the
+  container on the compute node.
+- `run_stage.sh` runs inside the container and maps the submitted mode onto the `preprocess`
+  command line flags.
+
+To use them, create a run directory, copy the scripts, and adapt the `#SBATCH` header in `batch.sh`
+to your cluster (partition, account, time and memory limits):
+
+```bash
+mkdir my_preprocessing && cd my_preprocessing
+cp -r <path/to/umami-preprocessing>/scripts/slurm .
+$EDITOR slurm/batch.sh
+```
+
+Then submit the stages in order, waiting for all jobs of one stage to finish before submitting the
+next:
+
+```bash
+./slurm/submit.sh --config <path/to/config.yaml> --dry-run prepare  # preview only
+./slurm/submit.sh --config <path/to/config.yaml> prepare
+./slurm/submit.sh --config <path/to/config.yaml> resampling
+./slurm/submit.sh --config <path/to/config.yaml> merge
+./slurm/submit.sh --config <path/to/config.yaml> normalise
+./slurm/submit.sh --config <path/to/config.yaml> plotting
+```
+
+Job logs are written to `logs/` in the current directory. Running `submit.sh` without a mode enters
+an interactive prompt for the mode and filters.
+
+The available modes and the jobs they submit:
+
+| Mode | Jobs | `preprocess` flags per job |
+|------|------|----------------------------|
+| `sequential` | 1 | full chain (`--prep`, `--resample`, `--merge`, `--norm`, `--plot`) |
+| `prepare` | one per component and split | `--prep --component <c> --split <s>` |
+| `resampling` | one per region and split | `--resample --region <r> --split <s>` |
+| `fine_resampling` | one per component and split | `--resample --region <r> --component <c> --split <s>` |
+| `merge` | one per split | `--merge --split <s>` |
+| `normalise` | 1 | `--norm` |
+| `plotting` | one per split | `--plot --split <s>` |
+
+!!!warning "Stage ordering and parallel h5py access"
+
+    All jobs of a stage must finish before the next stage is submitted, e.g. all `prepare` jobs
+    before `resampling`. Also run the [initial sample check](run.md#additional-scripts-initial-sample-check)
+    once before submitting `prepare` jobs in parallel — it creates the virtual datasets which can
+    get corrupted when created by multiple jobs at once.
+
+## Config-driven job lists
+
+`submit.sh` never hardcodes which components exist. It calls the `list_components` script (part of
+UPP) to enumerate the components defined in the `components:` block of your config:
+
+```bash
+list_components --config <path/to/config.yaml>
+```
+
+```text
+lowpt   ttbar   bjets   lowpt_ttbar_bjets
+highpt  zprime  bjets   highpt_zprime_bjets
+...
+```
+
+Only combinations actually defined in the config are submitted. The selection can be narrowed with
+filter flags, each taking a comma- or space-separated list:
+
+```bash
+./slurm/submit.sh --config <path/to/config.yaml> --regions lowpt --splits train prepare
+./slurm/submit.sh --config <path/to/config.yaml> --samples ttbar --flavs "bjets,cjets" fine_resampling
+```
+
+Note that enumerating the components fully validates the config, so a broken config fails directly
+on the login node instead of inside the batch jobs.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `UPP_IMAGE` | `docker://...upp-images/upp:latest` | Container image (`docker://` URI or local `.sif`) |
+| `UPP_BINDS` | `/home,/tmp` | Comma-separated paths bound into the container |
+| `THROTTLE` | `30` | Seconds between `sbatch` calls (`0` disables) |
+| `DRY_RUN` | `0` | Set to `1` to print the `sbatch` commands instead of submitting |
+
+Make sure `UPP_BINDS` covers your input ntuples and output directory if they live outside `/home`
+(e.g. on a scratch filesystem), and export `UPP_IMAGE`/`UPP_BINDS` in your shell so they are also
+picked up by the batch jobs.
+
+!!!warning "Keep the throttle enabled"
+
+    The delay between `sbatch` calls avoids hammering the scheduler and gives jobs time to start
+    up without all of them hitting the shared filesystem at once. Only disable it for small
+    submissions.
+
+!!!info "Configs outside the repository"
+
+    When you copy a config out of the repository, `!include` directives with relative paths no
+    longer resolve. Use absolute paths in `!include` lines of copied configs.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -128,6 +128,57 @@ python -m pip install .
     ```
 
 
+### Container image
+
+If you don't want to set up a Python environment at all, you can use the UPP container image.
+The CI builds `gitlab-registry.cern.ch/aft/training-images/upp-images/upp:latest` on every merge to
+`main` and a tagged image `upp:<tag>` (e.g. `upp:v0.3.1`) for every release. The image comes with UPP
+and its command line scripts (`preprocess`, `check_input_samples`, `list_components`) pre-installed.
+
+=== "apptainer"
+
+    On clusters (lxplus, HPC sites), apptainer can run the image directly from the registry:
+
+    ```bash
+    apptainer exec docker://gitlab-registry.cern.ch/aft/training-images/upp-images/upp:latest \
+        preprocess --config <path/to/config.yaml>
+    ```
+
+    The first `docker://` invocation converts the image to apptainer's SIF format, which takes a
+    while. If you run UPP repeatedly, pull the image once and use the local file instead:
+
+    ```bash
+    apptainer pull upp_latest.sif docker://gitlab-registry.cern.ch/aft/training-images/upp-images/upp:latest
+    apptainer exec upp_latest.sif preprocess --config <path/to/config.yaml>
+    ```
+
+    By default apptainer shares your home directory and working directory with the container. For a
+    cleaner environment use `--contain` and bind only the paths you need (your input ntuples and
+    output directory) with `-B`, keeping the working directory with `--pwd`:
+
+    ```bash
+    apptainer exec --contain --pwd "$PWD" -B /home -B /tmp -B <path/to/data> \
+        upp_latest.sif preprocess --config <path/to/config.yaml>
+    ```
+
+=== "docker"
+
+    With docker, mount your working directory and data paths into the container:
+
+    ```bash
+    docker run --rm -it -v $PWD:$PWD -w $PWD \
+        gitlab-registry.cern.ch/aft/training-images/upp-images/upp:latest \
+        preprocess --config <path/to/config.yaml>
+    ```
+
+!!!info "Pin a release tag for production"
+
+    `upp:latest` follows the `main` branch and changes over time. For reproducible production
+    preprocessing, use a tagged release image like `upp:v0.3.1` instead.
+
+For running UPP as batch jobs on Slurm clusters with the container image, see
+[Running on HPC](hpc.md).
+
 ### Run the tests (Optional)
 
 To ensure that the package is working correctly, you can run the tests using the pytest framework. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
 [project.scripts]
 preprocess = "upp.main:main"
 check_input_samples = "upp.utils.check_input_samples:main"
+list_components = "upp.utils.list_components:main"
 
 [tool.setuptools]
 packages = ["upp", "upp.classes", "upp.stages", "upp.utils"]

--- a/scripts/slurm/README.md
+++ b/scripts/slurm/README.md
@@ -1,0 +1,6 @@
+# Slurm submission scripts
+
+Submit UPP preprocessing stages as Slurm batch jobs running inside the UPP container image.
+
+See the [Running on HPC](https://umami-hep.github.io/umami-preprocessing/hpc/) documentation page
+for usage instructions.

--- a/scripts/slurm/batch.sh
+++ b/scripts/slurm/batch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#SBATCH --ntasks 1
+#SBATCH --cpus-per-task 4
+#SBATCH --mem-per-cpu 8000
+#SBATCH --time 1-00:00:00
+# Edit the header above for your cluster, e.g.
+# #SBATCH --partition <your-partition>
+# #SBATCH --account <your-account>
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE="${UPP_IMAGE:-docker://gitlab-registry.cern.ch/aft/training-images/upp-images/upp:latest}"
+BINDS="${UPP_BINDS:-/home,/tmp}"
+
+srun apptainer exec --contain --pwd "${PWD}" -B "${BINDS}" \
+    "${IMAGE}" "${SCRIPT_DIR}/run_stage.sh" "$@"

--- a/scripts/slurm/run_stage.sh
+++ b/scripts/slurm/run_stage.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Runs one preprocessing stage inside the container. Called by batch.sh.
+set -e
+
+usage() {
+    cat <<EOF
+Usage:
+  run_stage.sh <config>
+    # full chain (prep+resample+merge+norm+plot) with split=all
+
+  run_stage.sh <config> normalise|normalize
+  run_stage.sh <config> merge <split>
+  run_stage.sh <config> plotting <split>
+  run_stage.sh <config> prepare <component> <split>
+  run_stage.sh <config> resampling <region> <split>
+  run_stage.sh <config> fine_resampling <region> <component> <split>
+EOF
+}
+
+if [ "$#" -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    usage
+    exit 2
+fi
+
+CONFIG="$1"
+shift
+
+run_preprocess() {
+    preprocess --config "${CONFIG}" "$@"
+}
+
+need_args() {
+    # Usage: need_args <n_required> <mode> "$@"
+    local n_required="$1"
+    local mode="$2"
+    shift 2
+    if [ "$#" -lt "$n_required" ]; then
+        echo "ERROR: '$mode' needs ${n_required} argument(s), got $#." >&2
+        usage
+        exit 2
+    fi
+}
+
+if [ "$#" -eq 0 ]; then
+    echo "No mode given. Processing full chain."
+    run_preprocess --prep --split=all
+    run_preprocess --resample --split=all
+    run_preprocess --merge --split=all
+    run_preprocess --norm
+    run_preprocess --plot --split=all
+    exit 0
+fi
+
+MODE="$1"
+shift
+
+case "${MODE}" in
+    normalise|normalize)
+        echo "Normalisation selected. Processing..."
+        run_preprocess --norm
+        ;;
+
+    merge)
+        need_args 1 "merge" "$@"
+        echo "Start merging for $1. Processing..."
+        run_preprocess --merge --split "$1"
+        ;;
+
+    plotting)
+        need_args 1 "plotting" "$@"
+        echo "Plotting selected ($1). Processing..."
+        run_preprocess --plot --split "$1"
+        ;;
+
+    prepare)
+        need_args 2 "prepare" "$@"
+        echo "Start preparation for $1 ($2). Processing..."
+        run_preprocess --prep --component "$1" --split "$2"
+        ;;
+
+    resampling)
+        need_args 2 "resampling" "$@"
+        echo "Start resampling for $1 ($2). Processing..."
+        run_preprocess --resample --region "$1" --split "$2"
+        ;;
+
+    fine_resampling)
+        need_args 3 "fine_resampling" "$@"
+        echo "Start resampling for $2 ($3). Processing..."
+        run_preprocess --resample --region "$1" --component "$2" --split "$3"
+        ;;
+
+    *)
+        echo "Step '${MODE}' not supported!" >&2
+        usage
+        exit 2
+        ;;
+esac
+
+echo "Done!"

--- a/scripts/slurm/submit.sh
+++ b/scripts/slurm/submit.sh
@@ -1,0 +1,399 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE="${UPP_IMAGE:-docker://gitlab-registry.cern.ch/aft/training-images/upp-images/upp:latest}"
+
+# Throttle between sbatch calls (seconds). Set to 0 to disable.
+THROTTLE="${THROTTLE:-30}"
+
+# Dry-run: if 1, print commands but do not execute sbatch.
+DRY_RUN="${DRY_RUN:-0}"
+
+CONFIG=""
+
+# Filters on the components enumerated from the config; empty means "everything".
+declare -a REGION_FILTER=()
+declare -a SAMPLE_FILTER=()
+declare -a FLAV_FILTER=()
+declare -a SPLIT_FILTER=()
+
+# ---- Helpers --------------------------------------------------------------
+slugify() {
+  # keep alnum, dash, underscore; replace others with dash; squish repeats; trim
+  local s="${*:-}"
+  s="${s//[^[:alnum:]_-]/-}"
+  s="$(printf '%s' "$s" | sed -E 's/-+/-/g; s/^-+//; s/-+$//')"
+  # Slurm JobName limit is 128 chars; leave margin
+  printf '%.*s' 120 "$s"
+}
+
+build_job_name() {
+  local mode="${1:-sequential}"
+  shift || true
+  local prefix="upp-$(basename "${CONFIG%.*}")"
+  case "$mode" in
+    prepare)         slugify "${prefix}-prepare-${1:-component}-${2:-split}" ;;
+    fine_resampling) slugify "${prefix}-fres-${1:-region}-${2:-component}-${3:-split}" ;;
+    resampling)      slugify "${prefix}-resampling-${1:-region}-${2:-split}" ;;
+    merge)           slugify "${prefix}-merge-${1:-split}" ;;
+    normalise|normalize) slugify "${prefix}-normalise" ;;
+    plotting)        slugify "${prefix}-plotting-${1:-split}" ;;
+    sequential|*)    slugify "${prefix}-seq" ;;
+  esac
+}
+
+enumerate() {
+  # Use a local UPP installation when available, otherwise the container image
+  if command -v list_components >/dev/null 2>&1; then
+    list_components --config "${CONFIG}" "$@"
+  else
+    apptainer exec "${IMAGE}" list_components --config "${CONFIG}" "$@"
+  fi
+}
+
+append_list() {
+  # Append a comma/space separated list to the named array
+  local input="$1"
+  local out_name="$2"
+  local -a items=()
+  local x
+  IFS=', ' read -r -a items <<< "$input"
+  for x in "${items[@]}"; do
+    if [[ -n "$x" ]]; then
+      eval "$out_name+=(\"\$x\")"
+    fi
+  done
+}
+
+add_unique() {
+  # Append the value to the named array if not already present
+  local x="$1"
+  local out_name="$2"
+  local -a arr=()
+  eval "arr=(\"\${${out_name}[@]}\")"
+  local i
+  for i in "${arr[@]}"; do
+    if [[ "$i" == "$x" ]]; then
+      return 0
+    fi
+  done
+  eval "$out_name+=(\"\$x\")"
+}
+
+in_list() {
+  # in_list <value> [items...]; an empty list matches everything
+  local x="$1"
+  shift
+  if [[ $# -eq 0 ]]; then
+    return 0
+  fi
+  local i
+  for i in "$@"; do
+    if [[ "$i" == "$x" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+print_resolved_config() {
+  printf '\nResolved configuration:\n'
+  printf '  CONFIG     : %s\n' "$CONFIG"
+  printf '  IMAGE      : %s\n' "$IMAGE"
+  printf '  THROTTLE   : %s\n' "$THROTTLE"
+  printf '  COMPONENTS : %s\n' "${#COMPONENTS[@]}"
+  printf '  SPLITS     : %s\n' "${SPLITS[*]}"
+  printf '\n'
+}
+
+prompt_with_default() {
+  # Usage: prompt_with_default "Question" "default value"
+  local prompt="$1"
+  local default="$2"
+  local reply
+
+  read -r -p "${prompt} [${default}]: " reply
+  if [[ -z "${reply}" ]]; then
+    printf '%s\n' "${default}"
+  else
+    printf '%s\n' "${reply}"
+  fi
+}
+
+interactive_mode() {
+  echo
+  echo "No mode provided. Entering interactive mode."
+  echo
+  echo "Available modes:"
+  echo "  sequential prepare fine_resampling resampling merge normalise plotting"
+  echo
+
+  MODE="$(prompt_with_default "Select mode" "prepare")"
+
+  local regions samples flavs splits
+  regions="$(prompt_with_default "Regions"  "${ALL_REGIONS[*]}")"
+  samples="$(prompt_with_default "Samples"  "${ALL_SAMPLES[*]}")"
+  flavs="$(prompt_with_default "Flavours" "${ALL_FLAVS[*]}")"
+  splits="$(prompt_with_default "Splits"   "${SPLITS[*]}")"
+
+  append_list "${regions}" REGION_FILTER
+  append_list "${samples}" SAMPLE_FILTER
+  append_list "${flavs}"   FLAV_FILTER
+  SPLIT_FILTER=()
+  append_list "${splits}"  SPLIT_FILTER
+}
+
+submit() {
+  # Usage: submit [mode args...]
+  local jobname
+  jobname="$(build_job_name "$@")"
+
+  local -a cmd=(
+    sbatch
+    --job-name="$jobname"
+    --output="${PWD}/logs/%j_%x.out"
+    --error="${PWD}/logs/%j_%x.err"
+    "${SCRIPT_DIR}/batch.sh"
+    "$CONFIG"
+    "$@"
+  )
+
+  echo "Submitting: $jobname"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    printf 'DRY-RUN: '
+    printf '%q ' "${cmd[@]}"
+    printf '\n'
+  else
+    "${cmd[@]}"
+    if [[ "$THROTTLE" != "0" ]]; then
+      sleep "$THROTTLE"
+    fi
+  fi
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  submit.sh --config <yaml> [options] [mode]
+
+Modes:
+  (no mode)              # interactive mode: prompts for mode and filters
+  sequential             # one job running the full chain
+  prepare                # one job per component and split
+  fine_resampling        # one job per component and split
+  resampling             # one job per region and split
+  merge                  # one job per split
+  normalise|normalize    # one job
+  plotting               # one job per split
+
+Options:
+  --config <yaml>        # preprocessing config (required)
+  --dry-run              # do not call sbatch; print commands instead
+  --regions "<list>"     # only submit components in these regions
+  --samples "<list>"     # only submit components from these samples
+  --flavs "<list>"       # only submit components with these flavours
+  --splits "<list>"      # only submit these splits (default: train val test)
+  --throttle N           # seconds between sbatch calls (default 30; 0 disables)
+
+Env (still supported):
+  UPP_IMAGE=<uri>        # container image (docker:// URI or local .sif)
+  THROTTLE=<seconds>     # same as --throttle
+  DRY_RUN=1              # same as --dry-run
+
+List format:
+  Comma and/or space separated, e.g. "lowpt,highpt" or "lowpt highpt"
+
+Examples:
+  ./submit.sh --config configs/my-config.yaml --dry-run prepare
+  ./submit.sh --config configs/my-config.yaml --regions lowpt --splits train prepare
+  ./submit.sh --config configs/my-config.yaml resampling
+EOF
+}
+
+parse_args() {
+  local -a rest=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --config)
+        [[ $# -ge 2 ]] || { echo "ERROR: --config requires a value" >&2; exit 2; }
+        CONFIG="$2"
+        shift 2
+        ;;
+      --dry-run)
+        DRY_RUN=1
+        shift
+        ;;
+      --throttle)
+        [[ $# -ge 2 ]] || { echo "ERROR: --throttle requires a value" >&2; exit 2; }
+        THROTTLE="$2"
+        shift 2
+        ;;
+      --regions)
+        [[ $# -ge 2 ]] || { echo "ERROR: --regions requires a value" >&2; exit 2; }
+        append_list "$2" REGION_FILTER
+        shift 2
+        ;;
+      --samples)
+        [[ $# -ge 2 ]] || { echo "ERROR: --samples requires a value" >&2; exit 2; }
+        append_list "$2" SAMPLE_FILTER
+        shift 2
+        ;;
+      --flavs|--flavors|--flavours)
+        [[ $# -ge 2 ]] || { echo "ERROR: --flavs requires a value" >&2; exit 2; }
+        append_list "$2" FLAV_FILTER
+        shift 2
+        ;;
+      --splits)
+        [[ $# -ge 2 ]] || { echo "ERROR: --splits requires a value" >&2; exit 2; }
+        append_list "$2" SPLIT_FILTER
+        shift 2
+        ;;
+      --) # end of options
+        shift
+        rest+=("$@")
+        break
+        ;;
+      -*)
+        echo "ERROR: unknown option: $1" >&2
+        usage
+        exit 2
+        ;;
+      *)
+        rest+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  ARGS_REST=("${rest[@]}")
+}
+
+# ---- Main -----------------------------------------------------------------
+main() {
+  declare -a ARGS_REST=()
+  parse_args "$@"
+  set -- "${ARGS_REST[@]}"
+
+  if [[ -z "$CONFIG" ]]; then
+    echo "ERROR: --config is required" >&2
+    usage
+    exit 2
+  fi
+
+  # Enumerate all components defined in the config (TSV: region sample flavour name)
+  local -a ALL_ROWS=()
+  mapfile -t ALL_ROWS < <(enumerate)
+  if [[ ${#ALL_ROWS[@]} -eq 0 ]]; then
+    echo "ERROR: no components found in $CONFIG" >&2
+    exit 1
+  fi
+
+  local -a ALL_REGIONS=() ALL_SAMPLES=() ALL_FLAVS=()
+  local row region sample flavour name
+  for row in "${ALL_ROWS[@]}"; do
+    IFS=$'\t' read -r region sample flavour name <<< "$row"
+    add_unique "$region" ALL_REGIONS
+    add_unique "$sample" ALL_SAMPLES
+    add_unique "$flavour" ALL_FLAVS
+  done
+
+  MODE="${1:-}"
+  declare -a SPLITS=(train val test)
+  if [[ -z "$MODE" ]]; then
+    interactive_mode
+  fi
+  if [[ ${#SPLIT_FILTER[@]} -gt 0 ]]; then
+    SPLITS=("${SPLIT_FILTER[@]}")
+  fi
+
+  # Apply the filters
+  declare -a COMPONENTS=() REGIONS=()
+  for row in "${ALL_ROWS[@]}"; do
+    IFS=$'\t' read -r region sample flavour name <<< "$row"
+    if in_list "$region" "${REGION_FILTER[@]}" \
+        && in_list "$sample" "${SAMPLE_FILTER[@]}" \
+        && in_list "$flavour" "${FLAV_FILTER[@]}"; then
+      COMPONENTS+=("$row")
+      add_unique "$region" REGIONS
+    fi
+  done
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    print_resolved_config
+  fi
+
+  if [[ "$DRY_RUN" != "1" ]]; then
+    mkdir -p "${PWD}/logs"
+  fi
+
+  local split
+  case "$MODE" in
+    sequential)
+      echo "Start submission for sequential processing..."
+      submit
+      ;;
+
+    prepare)
+      echo "Start submission for preparation..."
+      for row in "${COMPONENTS[@]}"; do
+        IFS=$'\t' read -r region sample flavour name <<< "$row"
+        for split in "${SPLITS[@]}"; do
+          submit "prepare" "$name" "$split"
+        done
+      done
+      ;;
+
+    fine_resampling)
+      echo "Start submission for fine resampling..."
+      for row in "${COMPONENTS[@]}"; do
+        IFS=$'\t' read -r region sample flavour name <<< "$row"
+        for split in "${SPLITS[@]}"; do
+          submit "fine_resampling" "$region" "$name" "$split"
+        done
+      done
+      ;;
+
+    resampling)
+      echo "Start submission for resampling..."
+      for region in "${REGIONS[@]}"; do
+        for split in "${SPLITS[@]}"; do
+          submit "resampling" "$region" "$split"
+        done
+      done
+      ;;
+
+    merge)
+      echo "Start submission for merging..."
+      for split in "${SPLITS[@]}"; do
+        submit "merge" "$split"
+      done
+      ;;
+
+    normalise|normalize)
+      echo "Start submission for normalise..."
+      submit "normalise"
+      ;;
+
+    plotting)
+      echo "Start submission for plotting..."
+      for split in "${SPLITS[@]}"; do
+        submit "plotting" "$split"
+      done
+      ;;
+
+    *)
+      echo "Unsupported mode: '$MODE'" >&2
+      usage
+      exit 2
+      ;;
+  esac
+  echo "Done!"
+}
+
+main "$@"

--- a/tests/unit/utils/test_list_components.py
+++ b/tests/unit/utils/test_list_components.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from upp.utils.list_components import main
+
+CONFIG = Path(__file__).parents[3] / "upp/configs/test.yaml"
+
+
+def test_list_components(capsys):
+    main(["--config", str(CONFIG)])
+    rows = [line.split("\t") for line in capsys.readouterr().out.splitlines()]
+    assert len(rows) == 6
+    assert all(len(row) == 4 for row in rows)
+    assert ["lowpt", "ttbar", "bjets", "lowpt_ttbar_bjets"] in rows
+    assert ["highpt", "zprime", "cjets", "highpt_zprime_cjets"] in rows
+
+
+def test_list_components_regions(capsys):
+    main(["--config", str(CONFIG), "--regions"])
+    assert capsys.readouterr().out.splitlines() == ["lowpt", "highpt"]

--- a/upp/utils/list_components.py
+++ b/upp/utils/list_components.py
@@ -1,0 +1,84 @@
+"""List the components defined in a preprocessing config."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from ftag.cli_utils import HelpFormatter, valid_path
+
+from upp.classes.preprocessing_config import PreprocessingConfig
+
+
+def parse_args(args: Any) -> argparse.Namespace:
+    """Parse the command line arguments.
+
+    Parameters
+    ----------
+    args : Any
+        Command line arguments.
+
+    Returns
+    -------
+    argparse.Namespace
+        Namespace with the parsed command line arguments
+    """
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=HelpFormatter,
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        type=valid_path,
+        help="Path to config file",
+    )
+    parser.add_argument(
+        "--split",
+        default="train",
+        choices=["train", "val", "test"],
+        help="Split to load the config for (component names are split-independent)",
+    )
+    parser.add_argument(
+        "--regions",
+        action="store_true",
+        help="Only print the unique region names",
+    )
+
+    return parser.parse_args(args)
+
+
+def main(args: Any | None = None) -> None:
+    """List components as tab-separated `region sample flavour name` rows.
+
+    Parameters
+    ----------
+    args : Any | None, optional
+        Command line arguments, by default None
+    """
+    args = parse_args(args)
+
+    config = PreprocessingConfig.from_file(
+        config_path=args.config,
+        split=args.split,
+        skip_checks=True,
+        skip_config_copy=True,
+    )
+
+    if args.regions:
+        for region in config.components.regions:
+            print(region.name)
+        return
+
+    for component in config.components:
+        print(
+            component.region.name,
+            component.sample.name,
+            component.flavour.name,
+            component.name,
+            sep="\t",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/zensical.toml
+++ b/zensical.toml
@@ -18,6 +18,7 @@ nav = [
   { "Reweighting" = "reweighting.md" },
   { "Configuration" = "configuration.md" },
   { "Run" = "run.md" },
+  { "Running on HPC" = "hpc.md" },
   { "Umami integration" = "umami_int.md" },
   { "Contributing" = "contributing.md" },
   { "Docs development" = "docs_development.md" },


### PR DESCRIPTION
## Summary

This pull request introduces the following changes

* Document the CI-built container image (`upp:latest` / `upp:<tag>`) in the setup docs, with apptainer and docker usage
* Add a "Running on HPC" docs page covering interactive and Slurm batch usage of the container image
* Ship generic Slurm submission scripts (`scripts/slurm/`) that submit one job per component/region/split, deriving the job list from the preprocessing config
* Add a `list_components` console script that enumerates the components defined in a config

Relates to the following issues

* -

## Conformity
- [x] [Changelog entry](https://github.com/umami-hep/umami-preprocessing/blob/main/changelog.md)
- [x] [Documentation](https://umami-hep.github.io/umami-preprocessing/)
